### PR TITLE
Fix WarpCheckBg black flash on resize Lobby screen

### DIFF
--- a/client-3d/src/ui/WarpCheckBg.tsx
+++ b/client-3d/src/ui/WarpCheckBg.tsx
@@ -59,21 +59,27 @@ function initGL(canvas: HTMLCanvasElement) {
   gl.attachShader(prog, vs)
   gl.attachShader(prog, fs)
   gl.linkProgram(prog)
-  gl.useProgram(prog)
 
   // Fullscreen quad
-  const buf = gl.createBuffer()
+  const buf = gl.createBuffer()!
   gl.bindBuffer(gl.ARRAY_BUFFER, buf)
   gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1, -1, 1, -1, -1, 1, 1, 1]), gl.STATIC_DRAW)
 
   const aPos = gl.getAttribLocation(prog, 'a_pos')
-  gl.enableVertexAttribArray(aPos)
-  gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0)
-
   const uTime = gl.getUniformLocation(prog, 'u_time')
   const uRes = gl.getUniformLocation(prog, 'u_resolution')
 
-  return { gl, uTime, uRes }
+  // bindState: re-applies all GL state lost when canvas.width/height is reassigned.
+  // Must be called after every resize (resizing wipes the entire WebGL context state).
+  const bindState = () => {
+    gl.useProgram(prog)
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf)
+    gl.enableVertexAttribArray(aPos)
+    gl.vertexAttribPointer(aPos, 2, gl.FLOAT, false, 0, 0)
+  }
+  bindState()
+
+  return { gl, uTime, uRes, bindState }
 }
 
 export function WarpCheckBg() {
@@ -86,8 +92,11 @@ export function WarpCheckBg() {
     const ctx = initGL(canvas)
     if (!ctx) return
 
-    const { gl, uTime, uRes } = ctx
+    const { gl, uTime, uRes, bindState } = ctx
     let raf = 0
+
+    const FRAME_MS = 1000 / 15 // ~15fps cap
+    let lastDraw = 0
 
     const resize = () => {
       // Render at low res for a degraded / chunky look
@@ -95,13 +104,14 @@ export function WarpCheckBg() {
       canvas.width = Math.floor(canvas.clientWidth * scale)
       canvas.height = Math.floor(canvas.clientHeight * scale)
       gl.viewport(0, 0, canvas.width, canvas.height)
+      // Resizing canvas.width/height wipes all WebGL state — restore it
+      bindState()
+      // Force immediate redraw on next tick (bypass 15fps throttle)
+      lastDraw = 0
     }
 
     resize()
     window.addEventListener('resize', resize)
-
-    const FRAME_MS = 1000 / 15 // ~15fps cap
-    let lastDraw = 0
 
     const tick = (now: number) => {
       raf = requestAnimationFrame(tick)
@@ -126,7 +136,7 @@ export function WarpCheckBg() {
     <canvas
       ref={canvasRef}
       className="absolute inset-0 w-full h-full"
-      style={{ zIndex: 0, imageRendering: 'pixelated', filter: 'blur(3px)' }}
+      style={{ zIndex: 0, imageRendering: 'pixelated', filter: 'blur(3px)', backgroundColor: 'white' }}
     />
   )
 }


### PR DESCRIPTION
rebind GL state + force immediate redraw

canvas.width/height assignment wipes all WebGL context state (program binding, buffer binding, attrib pointers). After resize the next draw was on an unbound program, rendering nothing, and the 15fps throttle delayed the next draw by up to 66ms causing a visible black flash.

Fixes:
- Extract bindState() closure in initGL that restores program/buffer/attrib state
- Call bindState() in resize() immediately after dimension change
- Reset lastDraw = 0 in resize() to bypass 15fps throttle for the next frame
- Set backgroundColor: 'white' on canvas as safety net (white flash > black)