### PR TITLE
Remove framer-motion and @use-gesture/react, replace with CSS animations

### DIFF
--- a/client-3d/package.json
+++ b/client-3d/package.json
@@ -14,8 +14,6 @@
     "@react-three/drei": "^9.119.0",
     "@react-three/fiber": "^8.17.0",
     "@react-three/postprocessing": "^2.16.0",
-    "@use-gesture/react": "^10.3.1",
-    "framer-motion": "^12.34.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "react-player": "^2.16.1",

--- a/client-3d/src/ui/LobbyScreen.tsx
+++ b/client-3d/src/ui/LobbyScreen.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from 'react'
-import { motion } from 'framer-motion'
 
 import { getNetwork } from '../network/NetworkManager'
 import { useGameStore } from '../stores/gameStore'
@@ -94,8 +93,8 @@ export function LobbyScreen() {
       </div>
 
       {/* Input container - opaque green for legibility */}
-      <motion.div
-        className="relative z-10 mb-6 mt-0 p-6 rounded-xl border-2 shrink-0"
+      <div
+        className="relative z-10 mb-6 mt-0 p-6 rounded-xl border-2 shrink-0 lobby-card-enter"
         style={{
           backgroundColor: 'rgba(57, 255, 20, 0.45)',
           backdropFilter: 'blur(12px)',
@@ -105,9 +104,6 @@ export function LobbyScreen() {
             inset 0 0 20px rgba(57, 255, 20, 0.15)
           `,
         }}
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ duration: 0.5, delay: 0.2 }}
       >
         <div className="flex flex-col items-center gap-4 w-80">
           {/* Name input */}
@@ -139,22 +135,20 @@ export function LobbyScreen() {
           </div>
 
           {/* Join button */}
-          <motion.button
+          <button
             onClick={handleJoin}
             disabled={connecting || !name.trim()}
-            className="w-full relative overflow-hidden group
+            className="lobby-btn w-full relative overflow-hidden group
                        bg-green-700/40 border-2 border-toxic-green rounded-lg px-4 py-3
                        text-base font-mono font-bold text-white
                        hover:bg-green-600/50 hover:shadow-[0_0_40px_rgba(57,255,20,0.6)]
                        disabled:opacity-30 disabled:cursor-not-allowed disabled:hover:bg-green-700/40
                        transition-all duration-300"
-            whileHover={{ scale: name.trim() ? 1.03 : 1 }}
-            whileTap={{ scale: name.trim() ? 0.97 : 1 }}
           >
             {/* Button glow effect */}
-            <span className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent 
+            <span className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent
                             translate-x-[-100%] group-hover:translate-x-[100%] transition-transform duration-500" />
-            
+
             <span className="relative z-10 drop-shadow-[0_0_10px_rgba(0,0,0,0.8)]">
               {connecting ? (
                 <span className="flex items-center justify-center gap-2">
@@ -165,21 +159,17 @@ export function LobbyScreen() {
                 'Join'
               )}
             </span>
-          </motion.button>
+          </button>
 
           {/* Error message */}
           {error && (
-            <motion.p 
-              className="text-rave-pink text-sm font-mono text-center font-bold"
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-            >
+            <p className="lobby-error-enter text-rave-pink text-sm font-mono text-center font-bold">
               ⚠ {error}
-            </motion.p>
+            </p>
           )}
 
         </div>
-      </motion.div>
+      </div>
 
       <style>{`
         @keyframes scanline {
@@ -187,18 +177,34 @@ export function LobbyScreen() {
           50% { opacity: 1; transform: scaleX(1); }
         }
         @keyframes particle-float {
-          0%, 100% { 
-            transform: translateY(0) scale(0.5); 
-            opacity: 0; 
+          0%, 100% {
+            transform: translateY(0) scale(0.5);
+            opacity: 0;
           }
-          50% { 
-            transform: translateY(-40px) scale(1.2); 
-            opacity: 0.8; 
+          50% {
+            transform: translateY(-40px) scale(1.2);
+            opacity: 0.8;
           }
         }
         .particle-float {
           animation: particle-float ease-in-out infinite;
         }
+        @keyframes lobby-card-enter {
+          from { opacity: 0; transform: translateY(20px); }
+          to   { opacity: 1; transform: translateY(0); }
+        }
+        .lobby-card-enter {
+          animation: lobby-card-enter 0.5s ease-out 0.2s both;
+        }
+        @keyframes lobby-error-enter {
+          from { opacity: 0; }
+          to   { opacity: 1; }
+        }
+        .lobby-error-enter {
+          animation: lobby-error-enter 0.3s ease both;
+        }
+        .lobby-btn:not(:disabled):hover  { transform: scale(1.03); }
+        .lobby-btn:not(:disabled):active { transform: scale(0.97); }
       `}</style>
     </div>
   )

--- a/client-3d/src/ui/components/MutantLogo.tsx
+++ b/client-3d/src/ui/components/MutantLogo.tsx
@@ -1,16 +1,9 @@
-import { motion } from 'framer-motion'
-
 /**
  * "Club Mutant" Logo - Image-based logo centered in the carousel ring
  */
 export function MutantLogo() {
   return (
-    <motion.div
-      className="flex items-center justify-center"
-      initial={{ opacity: 0, scale: 0.8 }}
-      animate={{ opacity: 1, scale: 1 }}
-      transition={{ duration: 0.6, ease: 'easeOut' }}
-    >
+    <div className="flex items-center justify-center logo-fadein">
       <img
         src="/logo/ver1.png"
         alt="Club Mutant"
@@ -22,6 +15,15 @@ export function MutantLogo() {
         }}
         draggable={false}
       />
-    </motion.div>
+      <style>{`
+        @keyframes logo-fadein {
+          from { opacity: 0; transform: scale(0.8); }
+          to   { opacity: 1; transform: scale(1); }
+        }
+        .logo-fadein {
+          animation: logo-fadein 0.6s ease-out both;
+        }
+      `}</style>
+    </div>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,12 +241,6 @@ importers:
       '@react-three/postprocessing':
         specifier: ^2.16.0
         version: 2.19.1(@react-three/fiber@8.18.0(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(three@0.170.0))(@types/three@0.170.0)(react@18.3.1)(three@0.170.0)
-      '@use-gesture/react':
-        specifier: ^10.3.1
-        version: 10.3.1(react@18.3.1)
-      framer-motion:
-        specifier: ^12.34.1
-        version: 12.34.1(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -304,7 +298,7 @@ importers:
         version: 0.2.1(colyseus@0.17.8(@colyseus/auth@0.17.6(@colyseus/core@0.17.29)(express@5.2.1))(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/core@0.17.29)(@colyseus/redis-driver@0.17.6(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6))(@colyseus/redis-presence@0.17.6(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/uwebsockets-transport@0.17.12(@colyseus/core@0.17.29)(uwebsockets-express@2.0.2(@types/express@5.0.6)))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6))
       '@colyseus/core':
         specifier: ^0.17.0
-        version: 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1))(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
+        version: 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
       '@colyseus/monitor':
         specifier: ^0.17.0
         version: 0.17.7(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(zod@4.3.6)
@@ -3169,20 +3163,6 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
-  framer-motion@12.34.1:
-    resolution: {integrity: sha512-kcZyNaYQfvE2LlH6+AyOaJAQV4rGp5XbzfhsZpiSZcwDMfZUHhuxLWeyRzf5I7jip3qKRpuimPA9pXXfr111kQ==}
-    peerDependencies:
-      '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@emotion/is-prop-valid':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
     engines: {node: '>= 0.8'}
@@ -3894,12 +3874,6 @@ packages:
 
   moment@2.30.1:
     resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
-
-  motion-dom@12.34.1:
-    resolution: {integrity: sha512-SC7ZC5dRcGwku2g7EsPvI4q/EzHumUbqsDNumBmZTLFg+goBO5LTJvDu9MAxx+0mtX4IA78B2be/A3aRjY0jnw==}
-
-  motion-utils@12.29.2:
-    resolution: {integrity: sha512-G3kc34H2cX2gI63RqU+cZq+zWRRPSsNIOjpdl9TN4AQwC4sgwYPl/Q/Obf/d53nOm569T0fYK+tcoSV50BWx8A==}
 
   ms@2.0.0:
     resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
@@ -5786,7 +5760,7 @@ snapshots:
 
   '@colyseus/auth@0.17.6(@colyseus/core@0.17.29)(express@5.2.1)':
     dependencies:
-      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1))(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
+      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
       '@types/jsonwebtoken': 9.0.10
       connect-redis: 7.1.1(express-session@1.19.0)
       express: 5.2.1
@@ -5815,7 +5789,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@colyseus/core@0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1))(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)':
+  '@colyseus/core@0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)':
     dependencies:
       '@colyseus/better-call': 1.2.1(zod@4.3.6)
       '@colyseus/greeting-banner': 3.0.8
@@ -5837,7 +5811,7 @@ snapshots:
 
   '@colyseus/monitor@0.17.7(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(zod@4.3.6)':
     dependencies:
-      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1))(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
+      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
       express: 5.2.1
       node-os-utils: 2.0.1
     transitivePeerDependencies:
@@ -5856,13 +5830,13 @@ snapshots:
     dependencies:
       '@colyseus/auth': 0.17.6(@colyseus/core@0.17.29)(express@5.2.1)
       '@colyseus/better-call': 1.2.1(zod@4.3.6)
-      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1))(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
+      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
       express: 5.2.1
       zod: 4.3.6
 
   '@colyseus/redis-driver@0.17.6(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)':
     dependencies:
-      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1))(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
+      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
       ioredis: 5.9.2
     transitivePeerDependencies:
       - '@colyseus/better-call'
@@ -5875,7 +5849,7 @@ snapshots:
 
   '@colyseus/redis-presence@0.17.6(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)':
     dependencies:
-      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1))(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
+      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
       ioredis: 5.9.2
     transitivePeerDependencies:
       - '@colyseus/better-call'
@@ -5899,7 +5873,7 @@ snapshots:
       tslib: 2.8.1
       ws: 8.19.0
     optionalDependencies:
-      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1))(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
+      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -5916,7 +5890,7 @@ snapshots:
 
   '@colyseus/tools@0.17.18(@colyseus/core@0.17.29)(@colyseus/ws-transport@0.17.8)':
     dependencies:
-      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1))(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
+      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
       '@colyseus/ws-transport': 0.17.8(@colyseus/core@0.17.29)(express@5.2.1)
       '@pm2/io': 6.1.0
       dotenv: 17.2.3
@@ -5925,14 +5899,14 @@ snapshots:
 
   '@colyseus/uwebsockets-transport@0.17.12(@colyseus/core@0.17.29)(uwebsockets-express@2.0.2(@types/express@5.0.6))':
     dependencies:
-      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1))(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
+      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
       uWebSockets.js: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/fcfc622a4286909593b7f390056d89e0ca3b56b9
     optionalDependencies:
       uwebsockets-express: 2.0.2(@types/express@5.0.6)
 
   '@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1)':
     dependencies:
-      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1))(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
+      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
       '@types/ws': 8.18.1
       ws: 8.19.0
     optionalDependencies:
@@ -7797,7 +7771,7 @@ snapshots:
   colyseus@0.17.8(@colyseus/auth@0.17.6(@colyseus/core@0.17.29)(express@5.2.1))(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/core@0.17.29)(@colyseus/redis-driver@0.17.6(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6))(@colyseus/redis-presence@0.17.6(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/uwebsockets-transport@0.17.12(@colyseus/core@0.17.29)(uwebsockets-express@2.0.2(@types/express@5.0.6)))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6):
     dependencies:
       '@colyseus/auth': 0.17.6(@colyseus/core@0.17.29)(express@5.2.1)
-      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8(@colyseus/core@0.17.29)(express@5.2.1))(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
+      '@colyseus/core': 0.17.29(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
       '@colyseus/monitor': 0.17.7(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(zod@4.3.6)
       '@colyseus/playground': 0.17.10(@colyseus/auth@0.17.6(@colyseus/core@0.17.29)(express@5.2.1))(@colyseus/core@0.17.29)(express@5.2.1)(zod@4.3.6)
       '@colyseus/redis-driver': 0.17.6(@colyseus/better-call@1.2.1(zod@4.3.6))(@colyseus/schema@4.0.8(typescript@5.9.3))(@colyseus/ws-transport@0.17.8)(@pm2/io@6.1.0)(express@5.2.1)(zod@4.3.6)
@@ -8651,16 +8625,6 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
-  framer-motion@12.34.1(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
-    dependencies:
-      motion-dom: 12.34.1
-      motion-utils: 12.29.2
-      tslib: 2.8.1
-    optionalDependencies:
-      '@emotion/is-prop-valid': 1.4.0
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
   fresh@2.0.0: {}
 
   fs-extra@10.1.0:
@@ -9392,12 +9356,6 @@ snapshots:
   module-details-from-path@1.0.4: {}
 
   moment@2.30.1: {}
-
-  motion-dom@12.34.1:
-    dependencies:
-      motion-utils: 12.29.2
-
-  motion-utils@12.29.2: {}
 
   ms@2.0.0: {}
 


### PR DESCRIPTION
- Replaced all motion.* components in LobbyScreen.tsx and MutantLogo.tsx with plain HTML elements and CSS @keyframes (lobby-card-enter, lobby-error-enter, logo-fadein) + :hover/:active for button scale
- @use-gesture/react was unused — removed directly
- Both packages dropped from client-3d/package.json and lockfile