### PR TITLE
Fix client-dream build errors for Netlify deploy

### DIFF
--- a/client-dream/src/phaser/entities/Collectible.ts
+++ b/client-dream/src/phaser/entities/Collectible.ts
@@ -88,7 +88,7 @@ export class Collectible extends Phaser.GameObjects.Graphics {
     })
 
     // Persist
-    useDreamClientStore.getState().collectItem(this.collectibleId)
+    useDreamClientStore.getState().addCollectedItem(this.collectibleId)
     sendToParent({ type: 'DREAM_COLLECT', collectibleId: this.collectibleId })
   }
 }

--- a/client-dream/tsconfig.json
+++ b/client-dream/tsconfig.json
@@ -11,7 +11,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"]
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "types": ["vite/client"]
   },
   "include": ["src"]
 }


### PR DESCRIPTION
- Add vite/client types to tsconfig so import.meta.env is recognized
- Fix collectItem() → addCollectedItem() to match store method name