### PR TITLE
feat(konpyuuta): React rewrite, app suite, and bugfixes

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -17,7 +17,7 @@ COPY pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY package.json ./
 COPY types/package.json ./types/
 COPY server/package.json ./server/
-COPY packages/os5000k/package.json ./packages/os5000k/
+COPY packages/konpyuuta/package.json ./packages/konpyuuta/
 COPY packages/acs-web/package.json ./packages/acs-web/
 
 # Install all workspace dependencies
@@ -49,7 +49,7 @@ COPY pnpm-workspace.yaml pnpm-lock.yaml ./
 COPY package.json ./
 COPY types/package.json ./types/
 COPY server/package.json ./server/
-COPY packages/os5000k/package.json ./packages/os5000k/
+COPY packages/konpyuuta/package.json ./packages/konpyuuta/
 COPY packages/acs-web/package.json ./packages/acs-web/
 
 # Install production deps only

--- a/client-3d/src/ui/konpyuuta/KonpyuuTAShell.tsx
+++ b/client-3d/src/ui/konpyuuta/KonpyuuTAShell.tsx
@@ -1,17 +1,93 @@
+import { useMemo } from 'react'
 import { KonpyuuTADesktop } from '@club-mutant/konpyuuta'
 import { KonpyuuTAProvider } from '@club-mutant/konpyuuta/context'
+import type {
+  PlaylistService,
+  SocialService,
+  PlaylistTrack,
+  UserProfile,
+} from '../../../../packages/konpyuuta/src/types'
 import { useUIStore } from '../../stores/uiStore'
+import { usePlaylistStore } from '../../stores/playlistStore'
+import { useAuthStore } from '../../stores/authStore'
+import {
+  getUserProfile,
+  getMyAccount,
+  getWallPosts,
+  createWallPost,
+  deleteWallPost,
+  listFriends,
+} from '../../network/nakamaClient'
 import '../../../../packages/konpyuuta/src/styles/cde.css'
 
 export function KonpyuuTAShell() {
   const osActive = useUIStore((s) => s.osActive)
 
+  const playlistService = useMemo<PlaylistService>(() => {
+    const store = usePlaylistStore.getState
+    return {
+      getPlaylists: () => store().playlists,
+      createPlaylist: (name: string) => store().createPlaylist(name),
+      removePlaylist: (id: string) => store().removePlaylist(id),
+      addTrack: (playlistId: string, track: PlaylistTrack) => store().addTrack(playlistId, track),
+      removeTrack: (playlistId: string, trackId: string) =>
+        store().removeTrack(playlistId, trackId),
+      loadFromServer: () => store().loadFromServer(),
+    }
+  }, [])
+
+  const socialService = useMemo<SocialService>(() => {
+    const authStore = useAuthStore.getState
+    return {
+      getCurrentUserId: () => authStore().userId,
+      getCurrentUsername: () => authStore().username,
+      getUserProfile: async (userId: string): Promise<UserProfile> => {
+        const profile = await getUserProfile(userId)
+        return profile
+      },
+      getMyAccount: async (): Promise<UserProfile> => {
+        const account = await getMyAccount()
+        const user = account.user!
+        return {
+          user_id: user.id ?? '',
+          username: user.username ?? '',
+          display_name: user.display_name ?? '',
+          avatar_url: user.avatar_url ?? '',
+          metadata: (user.metadata ?? {}) as Record<string, unknown>,
+        }
+      },
+      getWallPosts: (targetUserId: string, cursor?: string) => getWallPosts(targetUserId, cursor),
+      createWallPost: (targetUserId: string, content: string) =>
+        createWallPost(targetUserId, content),
+      deleteWallPost: (postId: string, targetUserId: string) =>
+        deleteWallPost(postId, targetUserId),
+      listFriends: async () => {
+        const friends = await listFriends(0)
+        return friends.map((f) => {
+          const u = f.user!
+          return {
+            userId: u.id ?? '',
+            username: u.username ?? '',
+            displayName: u.display_name ?? '',
+            online: u.online ?? false,
+          }
+        })
+      },
+    }
+  }, [])
+
   if (!osActive) return null
 
   return (
     <KonpyuuTAProvider
+      playlistService={playlistService}
+      socialService={socialService}
       env={{
-        youtubeApiUrl: import.meta.env.VITE_YOUTUBE_API_URL,
+        youtubeApiUrl:
+          import.meta.env.VITE_YOUTUBE_SERVICE_URL ||
+          (window.location.hostname === 'localhost'
+            ? 'http://localhost:8081'
+            : `${window.location.origin}/youtube`),
       }}
     >
       <KonpyuuTADesktop onShutdown={() => useUIStore.getState().setOsActive(false)} />

--- a/packages/konpyuuta/package.json
+++ b/packages/konpyuuta/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "exports": {
     ".": "./src/index.ts",
-    "./context": "./src/context/KonpyuuTAContext.tsx"
+    "./context": "./src/context/KonpyuuTAContext.tsx",
+    "./types": "./src/types.ts"
   },
   "peerDependencies": {
     "react": "^18",

--- a/packages/konpyuuta/public/icons/apps/mutanttube.svg
+++ b/packages/konpyuuta/public/icons/apps/mutanttube.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="48" height="48">
+  <defs>
+    <linearGradient id="rustGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#B7410E"/>
+      <stop offset="100%" style="stop-color:#8B4513"/>
+    </linearGradient>
+    <linearGradient id="slimeGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#9ACD32"/>
+      <stop offset="100%" style="stop-color:#556B2F"/>
+    </linearGradient>
+  </defs>
+  <!-- Background -->
+  <rect x="2" y="2" width="44" height="44" rx="4" fill="#0a0a0a" stroke="#2F4F4F" stroke-width="2"/>
+  <!-- Play button triangle -->
+  <polygon points="16,12 16,36 36,24" fill="url(#slimeGrad)" stroke="#9ACD32" stroke-width="1"/>
+  <!-- Skull overlay hint -->
+  <circle cx="16" cy="20" r="3" fill="url(#rustGrad)"/>
+  <circle cx="16" cy="28" r="2" fill="url(#rustGrad)"/>
+  <!-- Corner accents -->
+  <rect x="4" y="4" width="6" height="2" fill="#B7410E"/>
+  <rect x="38" y="42" width="6" height="2" fill="#9ACD32"/>
+</svg>

--- a/packages/konpyuuta/src/components/AppRouter.tsx
+++ b/packages/konpyuuta/src/components/AppRouter.tsx
@@ -7,6 +7,7 @@ import { Calendar } from './apps/Calendar'
 import { AppManager } from './apps/AppManager'
 import { ManViewer } from './apps/ManViewer'
 import { Screenshot } from './apps/Screenshot'
+import { MutantTube } from './apps/MutantTube'
 
 interface AppRouterProps {
   app: string
@@ -41,6 +42,9 @@ export function AppRouter({ app, props: _props }: AppRouterProps) {
 
     case 'screenshot':
       return <Screenshot />
+
+    case 'mutanttube':
+      return <MutantTube />
 
     default:
       return (

--- a/packages/konpyuuta/src/components/AppRouter.tsx
+++ b/packages/konpyuuta/src/components/AppRouter.tsx
@@ -8,6 +8,9 @@ import { AppManager } from './apps/AppManager'
 import { ManViewer } from './apps/ManViewer'
 import { Screenshot } from './apps/Screenshot'
 import { MutantTube } from './apps/MutantTube'
+import { MutantBook } from './apps/MutantBook'
+import { Messenger } from './apps/Messenger'
+import { MutantMail } from './apps/MutantMail'
 
 interface AppRouterProps {
   app: string
@@ -45,6 +48,15 @@ export function AppRouter({ app, props: _props }: AppRouterProps) {
 
     case 'mutanttube':
       return <MutantTube />
+
+    case 'mutantbook':
+      return <MutantBook />
+
+    case 'messenger':
+      return <Messenger />
+
+    case 'mutantmail':
+      return <MutantMail />
 
     default:
       return (

--- a/packages/konpyuuta/src/components/Panel.tsx
+++ b/packages/konpyuuta/src/components/Panel.tsx
@@ -166,6 +166,10 @@ export function Panel() {
                 <img src="/icons/apps/lynx.png" alt="" />
                 <span>Lynx Text Browser</span>
               </div>
+              <div className="cde-subpanel-item" onClick={() => openApp('mutanttube', { title: 'MutantTube', size: { width: 900, height: 650 } })}>
+                <img src="/icons/apps/mutanttube.svg" alt="" />
+                <span>MutantTube</span>
+              </div>
             </div>
           )}
         </div>

--- a/packages/konpyuuta/src/components/apps/Messenger.tsx
+++ b/packages/konpyuuta/src/components/apps/Messenger.tsx
@@ -1,0 +1,288 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useKonpyuuTA } from '../../context/KonpyuuTAContext'
+import { useMessengerStore, type Message } from '../../stores/messengerStore'
+
+function timeAgo(timestamp: number): string {
+  const diff = Math.floor((Date.now() - timestamp) / 1000)
+
+  if (diff < 60) return 'just now'
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`
+  return `${Math.floor(diff / 86400)}d ago`
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+export function Messenger() {
+  const { socialService } = useKonpyuuTA()
+  const {
+    conversations,
+    activeConversationId,
+    messages,
+    typing,
+    buddyListOpen,
+    setConversations,
+    addConversation,
+    setActiveConversation,
+    addMessage,
+    setMessages,
+    setTyping,
+    setBuddyListOpen,
+    clearUnread,
+  } = useMessengerStore()
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [composeText, setComposeText] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const messagesEndRef = useRef<HTMLDivElement>(null)
+  const composeRef = useRef<HTMLTextAreaElement>(null)
+
+  const activeConv = conversations.find((c) => c.channelId === activeConversationId)
+  const activeMessages = activeConversationId ? messages[activeConversationId] || [] : []
+
+  // Load friends as potential conversation partners
+  useEffect(() => {
+    if (!socialService) {
+      setError('Social service not available')
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    socialService.listFriends()
+      .then((friends) => {
+        const convs = friends.map((f) => ({
+          channelId: `dm:${f.userId}`,
+          userId: f.userId,
+          username: f.username,
+          displayName: f.displayName,
+          online: f.online,
+          unread: 0,
+        }))
+        setConversations(convs)
+        setLoading(false)
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : 'Failed to load contacts')
+        setLoading(false)
+      })
+  }, [socialService, setConversations])
+
+  // Scroll to bottom when messages change
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [activeMessages.length])
+
+  // Clear unread when opening conversation
+  useEffect(() => {
+    if (activeConversationId) {
+      clearUnread(activeConversationId)
+    }
+  }, [activeConversationId, clearUnread])
+
+  const handleSelectConversation = useCallback((channelId: string) => {
+    setActiveConversation(channelId)
+    setBuddyListOpen(false)
+  }, [setActiveConversation, setBuddyListOpen])
+
+  const handleSend = useCallback(async () => {
+    if (!activeConversationId || !composeText.trim() || sending) return
+
+    const content = composeText.trim()
+    setComposeText('')
+    setSending(true)
+
+    // Add message optimistically
+    const tempId = `temp-${Date.now()}`
+    const tempMessage: Message = {
+      id: tempId,
+      senderId: 'me',
+      content,
+      createdAt: Date.now(),
+    }
+    addMessage(activeConversationId, tempMessage)
+
+    // TODO: Send via Nakama chat channel
+    // For now, simulate echo after delay
+    setTimeout(() => {
+      setSending(false)
+    }, 500)
+  }, [activeConversationId, composeText, sending, addMessage])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      handleSend()
+    }
+  }, [handleSend])
+
+  const handleBack = useCallback(() => {
+    setBuddyListOpen(true)
+  }, [setBuddyListOpen])
+
+  // Calculate total unread
+  const totalUnread = conversations.reduce((sum, c) => sum + c.unread, 0)
+
+  if (loading) {
+    return (
+      <div className="mm-root">
+        <div className="mm-loading">Loading contacts...</div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="mm-root">
+        <div className="mm-error">{error}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mm-root">
+      {/* Buddy List / Conversation List */}
+      {buddyListOpen ? (
+        <div className="mm-buddy-list">
+          <div className="mm-header">
+            <div className="mm-flower">✿</div>
+            <div className="mm-title">Mutant Messenger</div>
+            {totalUnread > 0 && (
+              <div className="mm-unread-badge">{totalUnread}</div>
+            )}
+          </div>
+
+          <div className="mm-status-bar">
+            {conversations.filter((c) => c.online).length} online
+          </div>
+
+          <div className="mm-contacts">
+            {/* Online first */}
+            {conversations
+              .filter((c) => c.online)
+              .sort((a, b) => a.displayName.localeCompare(b.displayName))
+              .map((conv) => (
+                <div
+                  key={conv.channelId}
+                  className={`mm-contact${conv.unread > 0 ? ' unread' : ''}`}
+                  onClick={() => handleSelectConversation(conv.channelId)}
+                >
+                  <div className="mm-contact-avatar">
+                    {conv.displayName.charAt(0).toUpperCase()}
+                  </div>
+                  <div className="mm-contact-info">
+                    <div className="mm-contact-name">{conv.displayName}</div>
+                    <div className="mm-contact-status online">Online</div>
+                  </div>
+                  {conv.unread > 0 && (
+                    <div className="mm-contact-unread">{conv.unread}</div>
+                  )}
+                </div>
+              ))}
+
+            {/* Separator if both online and offline */}
+            {conversations.some((c) => c.online) && conversations.some((c) => !c.online) && (
+              <div className="mm-separator">Offline</div>
+            )}
+
+            {/* Offline */}
+            {conversations
+              .filter((c) => !c.online)
+              .sort((a, b) => a.displayName.localeCompare(b.displayName))
+              .map((conv) => (
+                <div
+                  key={conv.channelId}
+                  className={`mm-contact offline${conv.unread > 0 ? ' unread' : ''}`}
+                  onClick={() => handleSelectConversation(conv.channelId)}
+                >
+                  <div className="mm-contact-avatar">
+                    {conv.displayName.charAt(0).toUpperCase()}
+                  </div>
+                  <div className="mm-contact-info">
+                    <div className="mm-contact-name">{conv.displayName}</div>
+                    <div className="mm-contact-status">Offline</div>
+                  </div>
+                  {conv.unread > 0 && (
+                    <div className="mm-contact-unread">{conv.unread}</div>
+                  )}
+                </div>
+              ))}
+
+            {conversations.length === 0 && (
+              <div className="mm-empty">No contacts yet</div>
+            )}
+          </div>
+        </div>
+      ) : (
+        /* Chat View */
+        <div className="mm-chat">
+          <div className="mm-chat-header">
+            <button className="mm-back-btn" onClick={handleBack}>
+              ◀
+            </button>
+            <div className="mm-chat-avatar">
+              {activeConv?.displayName.charAt(0).toUpperCase()}
+            </div>
+            <div className="mm-chat-info">
+              <div className="mm-chat-name">{activeConv?.displayName}</div>
+              <div className={`mm-chat-status ${activeConv?.online ? 'online' : ''}`}>
+                {activeConv?.online ? 'Online' : 'Offline'}
+              </div>
+            </div>
+          </div>
+
+          <div className="mm-messages">
+            {activeMessages.length === 0 ? (
+              <div className="mm-messages-empty">
+                Start a conversation with {activeConv?.displayName}
+              </div>
+            ) : (
+              activeMessages.map((msg) => (
+                <div
+                  key={msg.id}
+                  className={`mm-message ${msg.senderId === 'me' ? 'outgoing' : 'incoming'}`}
+                >
+                  <div className="mm-message-content">
+                    {escapeHtml(msg.content)}
+                  </div>
+                  <div className="mm-message-time">
+                    {timeAgo(msg.createdAt)}
+                  </div>
+                </div>
+              ))
+            )}
+            <div ref={messagesEndRef} />
+          </div>
+
+          {typing[activeConversationId || ''] && (
+            <div className="mm-typing">
+              {activeConv?.displayName} is typing...
+            </div>
+          )}
+
+          <div className="mm-compose">
+            <textarea
+              ref={composeRef}
+              placeholder="Type a message..."
+              value={composeText}
+              onChange={(e) => setComposeText(e.target.value)}
+              onKeyDown={handleKeyDown}
+              disabled={sending}
+            />
+            <button
+              className="mm-send-btn"
+              onClick={handleSend}
+              disabled={!composeText.trim() || sending}
+            >
+              Send
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/konpyuuta/src/components/apps/MutantBook.tsx
+++ b/packages/konpyuuta/src/components/apps/MutantBook.tsx
@@ -1,0 +1,403 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useKonpyuuTA } from '../../context/KonpyuuTAContext'
+import type { UserProfile, WallPost } from '../../types'
+
+type Tab = 'wall' | 'info' | 'friends'
+
+interface Friend {
+  userId: string
+  username: string
+  displayName: string
+  online: boolean
+}
+
+function timeAgo(timestamp: number): string {
+  const diff = Math.floor((Date.now() - timestamp) / 1000)
+
+  if (diff < 60) return `${diff}s`
+  if (diff < 3600) return `${Math.floor(diff / 60)}m`
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h`
+  if (diff < 2592000) return `${Math.floor(diff / 86400)}d`
+  return `${Math.floor(diff / 2592000)}mo`
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+export function MutantBook() {
+  const { socialService } = useKonpyuuTA()
+
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null)
+  const [currentUsername, setCurrentUsername] = useState<string | null>(null)
+  const [profileUserId, setProfileUserId] = useState<string | null>(null)
+  const [profileData, setProfileData] = useState<UserProfile | null>(null)
+
+  const [currentTab, setCurrentTab] = useState<Tab>('wall')
+  const [wallPosts, setWallPosts] = useState<WallPost[]>([])
+  const [wallCursor, setWallCursor] = useState<string | null>(null)
+  const [friends, setFriends] = useState<Friend[]>([])
+
+  const [composeText, setComposeText] = useState('')
+  const [posting, setPosting] = useState(false)
+  const [lookupInput, setLookupInput] = useState('')
+
+  const isSelf = profileUserId === currentUserId
+
+  // Load current user on mount
+  useEffect(() => {
+    if (!socialService) {
+      setError('Social service not available')
+      setLoading(false)
+      return
+    }
+
+    const userId = socialService.getCurrentUserId()
+    const username = socialService.getCurrentUsername()
+
+    if (!userId) {
+      setError('Not logged in')
+      setLoading(false)
+      return
+    }
+
+    setCurrentUserId(userId)
+    setCurrentUsername(username)
+    setProfileUserId(userId)
+  }, [socialService])
+
+  // Load profile when profileUserId changes
+  useEffect(() => {
+    if (!socialService || !profileUserId) return
+
+    setLoading(true)
+    setError(null)
+
+    socialService.getUserProfile(profileUserId)
+      .then((profile) => {
+        setProfileData(profile)
+        setLoading(false)
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : 'Failed to load profile')
+        setLoading(false)
+      })
+  }, [socialService, profileUserId])
+
+  // Load wall posts when profileUserId changes
+  const loadWallPosts = useCallback(async () => {
+    if (!socialService || !profileUserId) return
+
+    try {
+      const result = await socialService.getWallPosts(profileUserId)
+      setWallPosts(result.posts)
+      setWallCursor(result.cursor ?? null)
+    } catch (err) {
+      console.error('Failed to load wall posts:', err)
+    }
+  }, [socialService, profileUserId])
+
+  // Load friends when tab changes to 'friends'
+  const loadFriends = useCallback(async () => {
+    if (!socialService) return
+
+    try {
+      const result = await socialService.listFriends()
+      setFriends(result)
+    } catch (err) {
+      console.error('Failed to load friends:', err)
+    }
+  }, [socialService])
+
+  useEffect(() => {
+    if (currentTab === 'wall') {
+      loadWallPosts()
+    } else if (currentTab === 'friends') {
+      loadFriends()
+    }
+  }, [currentTab, loadWallPosts, loadFriends])
+
+  const handlePost = async () => {
+    if (!socialService || !profileUserId || !composeText.trim() || posting) return
+
+    setPosting(true)
+    try {
+      const post = await socialService.createWallPost(profileUserId, composeText.trim())
+      setWallPosts((prev) => [post, ...prev])
+      setComposeText('')
+    } catch (err) {
+      console.error('Failed to post:', err)
+    } finally {
+      setPosting(false)
+    }
+  }
+
+  const handleDelete = async (postId: string) => {
+    if (!socialService || !profileUserId) return
+    if (!confirm('Delete this post?')) return
+
+    try {
+      await socialService.deleteWallPost(postId, profileUserId)
+      setWallPosts((prev) => prev.filter((p) => p.postId !== postId))
+    } catch (err) {
+      console.error('Failed to delete:', err)
+    }
+  }
+
+  const handleLookup = () => {
+    const userId = lookupInput.trim()
+    if (userId) {
+      setProfileUserId(userId)
+      setCurrentTab('wall')
+      setLookupInput('')
+    }
+  }
+
+  const goToProfile = (userId: string) => {
+    setProfileUserId(userId)
+    setCurrentTab('wall')
+  }
+
+  const goToMyProfile = () => {
+    if (currentUserId) {
+      setProfileUserId(currentUserId)
+      setCurrentTab('wall')
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="mb-root">
+        <div className="mb-loading">Loading profile...</div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="mb-root">
+        <div className="mb-error">{error}</div>
+      </div>
+    )
+  }
+
+  if (!profileData) {
+    return (
+      <div className="mb-root">
+        <div className="mb-error">Profile not found</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="mb-root">
+      {/* Lookup bar */}
+      <div className="mb-lookup">
+        {!isSelf && (
+          <button className="mb-back-btn" onClick={goToMyProfile}>
+            ← My Profile
+          </button>
+        )}
+        <input
+          className="mb-lookup-input"
+          placeholder="Search user by ID..."
+          value={lookupInput}
+          onChange={(e) => setLookupInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && handleLookup()}
+        />
+        <button className="mb-lookup-btn" onClick={handleLookup}>
+          Go
+        </button>
+      </div>
+
+      {/* Profile header */}
+      <div className="mb-header">
+        <div className="mb-avatar">
+          {profileData.avatar_url ? (
+            <img src={profileData.avatar_url} alt="" onError={(e) => {
+              (e.target as HTMLImageElement).style.display = 'none'
+            }} />
+          ) : (
+            <span>{(profileData.username || '?').charAt(0).toUpperCase()}</span>
+          )}
+        </div>
+        <div className="mb-header-info">
+          <div className="mb-name">
+            {profileData.display_name || profileData.username || '???'}
+          </div>
+          <div className="mb-username">@{profileData.username || '???'}</div>
+          {profileData.metadata.bio && (
+            <div className="mb-bio">"{profileData.metadata.bio}"</div>
+          )}
+          {!isSelf && (
+            <div className="mb-header-actions">
+              <button className="mb-friend-btn">+ Add Friend</button>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div className="mb-tabs">
+        <button
+          className={`mb-tab${currentTab === 'wall' ? ' active' : ''}`}
+          onClick={() => setCurrentTab('wall')}
+        >
+          Wall
+        </button>
+        <button
+          className={`mb-tab${currentTab === 'info' ? ' active' : ''}`}
+          onClick={() => setCurrentTab('info')}
+        >
+          Info
+        </button>
+        <button
+          className={`mb-tab${currentTab === 'friends' ? ' active' : ''}`}
+          onClick={() => setCurrentTab('friends')}
+        >
+          Friends
+        </button>
+      </div>
+
+      {/* Content */}
+      <div className="mb-content">
+        {currentTab === 'wall' && (
+          <div className="mb-wall">
+            {/* Compose */}
+            {currentUserId && (
+              <div className="mb-compose">
+                <textarea
+                  placeholder={
+                    isSelf
+                      ? "What's on your mind?"
+                      : `Write something on ${profileData.display_name || profileData.username}'s wall...`
+                  }
+                  value={composeText}
+                  onChange={(e) => setComposeText(e.target.value)}
+                />
+                <div className="mb-compose-actions">
+                  <button
+                    className="mb-post-btn"
+                    onClick={handlePost}
+                    disabled={!composeText.trim() || posting}
+                  >
+                    {posting ? 'Posting...' : 'Post'}
+                  </button>
+                </div>
+              </div>
+            )}
+
+            {/* Posts */}
+            {wallPosts.length === 0 ? (
+              <div className="mb-empty">No wall posts yet.</div>
+            ) : (
+              wallPosts.map((post) => (
+                <div key={post.postId} className="mb-post">
+                  <div className="mb-post-avatar">
+                    {post.authorUsername.charAt(0).toUpperCase()}
+                  </div>
+                  <div className="mb-post-body">
+                    <div
+                      className="mb-post-author"
+                      onClick={() => goToProfile(post.authorId)}
+                    >
+                      {post.authorUsername}
+                    </div>
+                    <div className="mb-post-content">
+                      {escapeHtml(post.content)}
+                    </div>
+                    <div className="mb-post-meta">
+                      <span>{timeAgo(post.createdAt)}</span>
+                      {post.authorId === currentUserId && (
+                        <button
+                          className="mb-delete-btn"
+                          onClick={() => handleDelete(post.postId)}
+                        >
+                          Delete
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
+
+            {/* Load more */}
+            {wallCursor && (
+              <div className="mb-load-more">
+                <button onClick={loadWallPosts}>Load More</button>
+              </div>
+            )}
+          </div>
+        )}
+
+        {currentTab === 'info' && (
+          <div className="mb-info">
+            {profileData.metadata.bio && (
+              <div className="mb-info-field">
+                <div className="mb-info-label">Bio</div>
+                <div className="mb-info-value">
+                  {profileData.metadata.bio}
+                </div>
+              </div>
+            )}
+            {profileData.metadata.favoriteSong && (
+              <div className="mb-info-field">
+                <div className="mb-info-label">Favorite Song</div>
+                <div className="mb-info-value">
+                  {profileData.metadata.favoriteSong}
+                </div>
+              </div>
+            )}
+            {profileData.metadata.links && profileData.metadata.links.length > 0 && (
+              <div className="mb-info-field">
+                <div className="mb-info-label">Links</div>
+                <div className="mb-info-value">
+                  {profileData.metadata.links.map((link, i) => (
+                    <div key={i}>
+                      <a href={link.url} target="_blank" rel="noopener noreferrer">
+                        {link.label}
+                      </a>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+            {!profileData.metadata.bio && !profileData.metadata.favoriteSong && !profileData.metadata.links?.length && (
+              <div className="mb-empty">No info yet.</div>
+            )}
+          </div>
+        )}
+
+        {currentTab === 'friends' && (
+          <div className="mb-friends">
+            {friends.length === 0 ? (
+              <div className="mb-empty">No friends yet.</div>
+            ) : (
+              friends.map((friend) => (
+                <div
+                  key={friend.userId}
+                  className="mb-friend-card"
+                  onClick={() => goToProfile(friend.userId)}
+                >
+                  <div className="mb-friend-avatar">
+                    {friend.displayName.charAt(0).toUpperCase()}
+                  </div>
+                  <div className="mb-friend-name">
+                    {friend.displayName || friend.username}
+                  </div>
+                  <div className={`mb-friend-status ${friend.online ? 'online' : 'offline'}`}>
+                    {friend.online ? 'Online' : 'Offline'}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/packages/konpyuuta/src/components/apps/MutantMail.tsx
+++ b/packages/konpyuuta/src/components/apps/MutantMail.tsx
@@ -1,0 +1,288 @@
+import { useState, useCallback, useEffect } from 'react'
+import {
+  useMailStore,
+  type MailMessage,
+  type MailFolder,
+} from '../../stores/mailStore'
+
+const FOLDER_LABELS: Record<MailFolder, string> = {
+  inbox: 'Inbox',
+  sent: 'Sent',
+  drafts: 'Drafts',
+  trash: 'Trash',
+}
+
+function formatDate(timestamp: number): string {
+  const date = new Date(timestamp)
+  const now = new Date()
+  const isToday = date.toDateString() === now.toDateString()
+
+  if (isToday) {
+    return date.toLocaleTimeString('en-US', {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    })
+  }
+
+  return date.toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+export function MutantMail() {
+  const {
+    messages,
+    selectedMessageId,
+    currentFolder,
+    composing,
+    setSelectedMessage,
+    setCurrentFolder,
+    setComposing,
+    addMessage,
+    removeMessage,
+    markAsRead,
+    moveToTrash,
+    getFolderMessages,
+    getUnreadCount,
+  } = useMailStore()
+
+  const [toField, setToField] = useState('')
+  const [subjectField, setSubjectField] = useState('')
+  const [bodyField, setBodyField] = useState('')
+  const [sending, setSending] = useState(false)
+
+  const folderMessages = getFolderMessages(currentFolder)
+  const unreadCount = getUnreadCount(currentFolder)
+  const selectedMessage = messages.find((m) => m.id === selectedMessageId)
+
+  // Mark as read when selected
+  useEffect(() => {
+    if (selectedMessageId && selectedMessage && !selectedMessage.read) {
+      markAsRead(selectedMessageId)
+    }
+  }, [selectedMessageId, selectedMessage, markAsRead])
+
+  const handleSelectMessage = useCallback((id: string) => {
+    setSelectedMessage(id)
+    setComposing(false)
+  }, [setSelectedMessage, setComposing])
+
+  const handleDelete = useCallback(() => {
+    if (!selectedMessageId) return
+
+    if (currentFolder === 'trash') {
+      if (confirm('Permanently delete this message?')) {
+        removeMessage(selectedMessageId)
+      }
+    } else {
+      moveToTrash(selectedMessageId)
+    }
+  }, [selectedMessageId, currentFolder, removeMessage, moveToTrash])
+
+  const handleSend = useCallback(async () => {
+    if (!toField.trim() || !subjectField.trim() || sending) return
+
+    setSending(true)
+
+    // Create sent message
+    const sentMessage: MailMessage = {
+      id: crypto.randomUUID(),
+      from: 'me',
+      to: toField.trim(),
+      subject: subjectField.trim(),
+      body: bodyField.trim(),
+      read: true,
+      folder: 'sent',
+      createdAt: Date.now(),
+    }
+
+    addMessage(sentMessage)
+
+    // Reset form
+    setToField('')
+    setSubjectField('')
+    setBodyField('')
+    setComposing(false)
+    setSending(false)
+
+    // Switch to sent folder
+    setCurrentFolder('sent')
+  }, [toField, subjectField, bodyField, sending, addMessage, setComposing, setCurrentFolder])
+
+  const handleNewMessage = useCallback(() => {
+    setComposing(true)
+    setSelectedMessage(null)
+    setToField('')
+    setSubjectField('')
+    setBodyField('')
+  }, [setComposing, setSelectedMessage])
+
+  const handleReply = useCallback(() => {
+    if (!selectedMessage) return
+
+    setComposing(true)
+    setToField(selectedMessage.from)
+    setSubjectField(`Re: ${selectedMessage.subject}`)
+    setBodyField(`\n\n--- Original Message ---\n${selectedMessage.body}`)
+  }, [selectedMessage])
+
+  return (
+    <div className="ml-root">
+      {/* Folder sidebar */}
+      <div className="ml-sidebar">
+        <div className="ml-logo">
+          <span className="ml-logo-icon">✉</span>
+          <span className="ml-logo-text">MutantMail</span>
+        </div>
+
+        <button className="ml-compose-btn" onClick={handleNewMessage}>
+          Compose
+        </button>
+
+        <div className="ml-folders">
+          {(['inbox', 'sent', 'drafts', 'trash'] as MailFolder[]).map((folder) => {
+            const count = getUnreadCount(folder)
+            return (
+              <div
+                key={folder}
+                className={`ml-folder${currentFolder === folder ? ' active' : ''}`}
+                onClick={() => setCurrentFolder(folder)}
+              >
+                <span className="ml-folder-icon">
+                  {folder === 'inbox' && '📥'}
+                  {folder === 'sent' && '📤'}
+                  {folder === 'drafts' && '📝'}
+                  {folder === 'trash' && '🗑️'}
+                </span>
+                <span className="ml-folder-label">{FOLDER_LABELS[folder]}</span>
+                {count > 0 && (
+                  <span className="ml-folder-count">{count}</span>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Main content */}
+      <div className="ml-main">
+        {/* Message list */}
+        <div className="ml-list">
+          <div className="ml-list-header">
+            <span className="ml-list-title">{FOLDER_LABELS[currentFolder]}</span>
+            {unreadCount > 0 && (
+              <span className="ml-list-count">{unreadCount} unread</span>
+            )}
+          </div>
+
+          <div className="ml-messages">
+            {folderMessages.length === 0 ? (
+              <div className="ml-empty">No messages in {FOLDER_LABELS[currentFolder].toLowerCase()}</div>
+            ) : (
+              folderMessages.map((msg) => (
+                <div
+                  key={msg.id}
+                  className={`ml-message-row${msg.read ? '' : ' unread'}${selectedMessageId === msg.id ? ' selected' : ''}`}
+                  onClick={() => handleSelectMessage(msg.id)}
+                >
+                  <div className="ml-message-checkbox">
+                    <input type="checkbox" />
+                  </div>
+                  <div className="ml-message-from">
+                    {msg.read ? '' : <span className="ml-unread-dot">●</span>}
+                    {msg.from}
+                  </div>
+                  <div className="ml-message-subject">{msg.subject}</div>
+                  <div className="ml-message-date">{formatDate(msg.createdAt)}</div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        {/* Preview pane */}
+        <div className="ml-preview">
+          {composing ? (
+            <div className="ml-compose-form">
+              <div className="ml-compose-header">New Message</div>
+              <div className="ml-compose-field">
+                <label>To:</label>
+                <input
+                  type="text"
+                  value={toField}
+                  onChange={(e) => setToField(e.target.value)}
+                  placeholder="recipient@example.com"
+                />
+              </div>
+              <div className="ml-compose-field">
+                <label>Subject:</label>
+                <input
+                  type="text"
+                  value={subjectField}
+                  onChange={(e) => setSubjectField(e.target.value)}
+                  placeholder="Enter subject"
+                />
+              </div>
+              <div className="ml-compose-body">
+                <textarea
+                  value={bodyField}
+                  onChange={(e) => setBodyField(e.target.value)}
+                  placeholder="Write your message..."
+                />
+              </div>
+              <div className="ml-compose-actions">
+                <button
+                  className="ml-send-btn"
+                  onClick={handleSend}
+                  disabled={!toField.trim() || !subjectField.trim() || sending}
+                >
+                  {sending ? 'Sending...' : 'Send'}
+                </button>
+                <button
+                  className="ml-cancel-btn"
+                  onClick={() => setComposing(false)}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : selectedMessage ? (
+            <div className="ml-message-view">
+              <div className="ml-view-header">
+                <div className="ml-view-subject">{selectedMessage.subject}</div>
+                <div className="ml-view-meta">
+                  <span className="ml-view-from">From: {selectedMessage.from}</span>
+                  <span className="ml-view-to">To: {selectedMessage.to}</span>
+                  <span className="ml-view-date">
+                    {new Date(selectedMessage.createdAt).toLocaleString()}
+                  </span>
+                </div>
+              </div>
+              <div className="ml-view-body">
+                {escapeHtml(selectedMessage.body)}
+              </div>
+              <div className="ml-view-actions">
+                <button className="ml-action-btn" onClick={handleReply}>
+                  Reply
+                </button>
+                <button className="ml-action-btn delete" onClick={handleDelete}>
+                  {currentFolder === 'trash' ? 'Delete Forever' : 'Delete'}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="ml-no-selection">
+              Select a message to read
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/konpyuuta/src/components/apps/MutantTube.tsx
+++ b/packages/konpyuuta/src/components/apps/MutantTube.tsx
@@ -1,0 +1,742 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useKonpyuuTA } from '../../context/KonpyuuTAContext'
+import type { Playlist, PlaylistTrack } from '../../types'
+
+type View = 'homepage' | 'playlists' | 'watch' | 'playlist-detail'
+
+interface YouTubeVideo {
+  id?: string
+  videoId?: string
+  title: string
+  thumbnail?: string
+  viewCount?: number
+  publishedAt?: string
+}
+
+interface YouTubeSearchResult {
+  videoId: string
+  title: string
+  thumbnail?: string
+  viewCount?: number
+  publishedAt?: string
+}
+
+interface Video {
+  id: string
+  title: string
+  thumbnail?: string
+  viewCount?: number
+  publishedAt?: string
+}
+
+const ITEMS_PER_PAGE = 12
+
+const WEIRD_TERMS = [
+  '1996 local TV commercial',
+  'forgotten VHS home video 1993',
+  'obscure public access show 1998',
+  'weird internet video 2002',
+  'rare 90s cartoon pilot',
+  'lost TV special 1995',
+  'public access cable 1997',
+  'strange music video 1994',
+]
+
+const CATEGORY_TERMS: Record<string, string[]> = {
+  'home-videos': ['home video 1990', 'family VHS 1995', 'amateur recording 1998'],
+  'music': ['music video 1994', 'live performance 1996', 'MTV underground'],
+  'comedy': ['stand up 1995', 'comedy sketch 1990s', 'funny home video'],
+  'tv-shows': ['90s TV show', 'pilot episode rare', 'public access TV'],
+  'weird': ['weird video', 'strange footage', 'bizarre clip'],
+  'vintage': ['vintage footage', 'old film', 'retro video'],
+  'public-access': ['public access', 'cable access', 'community TV'],
+  'corrupted': ['corrupted video', 'glitch footage', 'damaged VHS'],
+}
+
+function pickRandom(arr: string[], n: number): string[] {
+  const copy = arr.slice()
+  const result: string[] = []
+  for (let i = 0; i < n && copy.length > 0; i++) {
+    const idx = Math.floor(Math.random() * copy.length)
+    result.push(copy.splice(idx, 1)[0]!)
+  }
+  return result
+}
+
+function formatTimeAgo(dateString: string): string {
+  try {
+    const date = new Date(dateString)
+    const now = new Date()
+    const diff = Math.floor((now.getTime() - date.getTime()) / 1000)
+
+    if (diff < 60) return `${diff} SECONDS AGO`
+    if (diff < 3600) return `${Math.floor(diff / 60)} MINUTES AGO`
+    if (diff < 86400) return `${Math.floor(diff / 3600)} HOURS AGO`
+    if (diff < 2592000) return `${Math.floor(diff / 86400)} DAYS AGO`
+    if (diff < 31536000) return `${Math.floor(diff / 2592000)} MONTHS AGO`
+    return `${Math.floor(diff / 31536000)} YEARS AGO`
+  } catch {
+    return 'UNKNOWN DATE'
+  }
+}
+
+function extractYouTubeId(item: PlaylistTrack): string {
+  if (item.id && /^[a-zA-Z0-9_-]{11}$/.test(item.id)) return item.id
+  if (item.link) {
+    const m = item.link.match(/[?&]v=([a-zA-Z0-9_-]{11})/)
+    if (m) return m[1]!
+  }
+  return item.id
+}
+
+export function MutantTube() {
+  const { playlistService, env } = useKonpyuuTA()
+
+  const [view, setView] = useState<View>('homepage')
+  const [loading, setLoading] = useState(true)
+  const [loadingMessage, setLoadingMessage] = useState('INITIALIZING ARCHIVE...')
+  const [error, setError] = useState<string | null>(null)
+
+  const [searchQuery, setSearchQuery] = useState('')
+  const [currentCategory, setCurrentCategory] = useState<string | null>(null)
+  const [results, setResults] = useState<Video[]>([])
+  const [currentPage, setCurrentPage] = useState(1)
+  const [totalPages, setTotalPages] = useState(1)
+
+  const [playlists, setPlaylists] = useState<Playlist[]>([])
+  const [currentPlaylist, setCurrentPlaylist] = useState<Playlist | null>(null)
+  const [currentVideo, setCurrentVideo] = useState<Video | null>(null)
+
+  const [sidebarHidden, setSidebarHidden] = useState(false)
+  const [statusText, setStatusText] = useState('Ready')
+
+  const youtubeApiUrl = env.youtubeApiUrl
+
+  const searchYouTube = useCallback(async (q: string, limit: number): Promise<YouTubeSearchResult[]> => {
+    if (!youtubeApiUrl) throw new Error('YouTube API URL not configured')
+    const res = await fetch(`${youtubeApiUrl}/search?q=${encodeURIComponent(q)}&limit=${limit}`)
+    if (!res.ok) throw new Error(`YouTube search failed: ${res.status}`)
+    const data = await res.json()
+    const items = (data.items || []) as YouTubeVideo[]
+    return items
+      .filter((v) => v.id || v.videoId)
+      .map((v) => ({
+        videoId: (v.id ?? v.videoId) as string,
+        title: v.title,
+        thumbnail: v.thumbnail,
+        viewCount: v.viewCount,
+        publishedAt: v.publishedAt,
+      }))
+  }, [youtubeApiUrl])
+
+  const loadHomepage = useCallback(async () => {
+    setLoading(true)
+    setLoadingMessage('SCANNING ARCHIVES...')
+    setStatusText('Retrieving data fragments...')
+    setError(null)
+
+    try {
+      const terms = pickRandom(WEIRD_TERMS, 3)
+      setStatusText(`Querying: ${terms[0]!.substring(0, 20)}...`)
+
+      const searchResults = await Promise.all(terms.map(t => searchYouTube(t, 8)))
+      const seen = new Set<string>()
+      const all: Video[] = []
+
+      searchResults.forEach(results => {
+        results.forEach(v => {
+          if (v.videoId && !seen.has(v.videoId)) {
+            seen.add(v.videoId)
+            all.push({
+              id: v.videoId,
+              title: v.title,
+              thumbnail: v.thumbnail,
+              viewCount: v.viewCount,
+              publishedAt: v.publishedAt,
+            })
+          }
+        })
+      })
+
+      all.sort((a, b) => (a.viewCount || 0) - (b.viewCount || 0))
+      setResults(all)
+      setCurrentPage(1)
+      setTotalPages(Math.ceil(all.length / ITEMS_PER_PAGE))
+      setLoading(false)
+      setStatusText(`${all.length} fragments recovered`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+      setLoading(false)
+    }
+  }, [searchYouTube])
+
+  const loadCategory = useCallback(async (category: string, categoryName: string) => {
+    setLoading(true)
+    setLoadingMessage('DECRYPTING ARCHIVE...')
+    setStatusText('Decrypting category data...')
+    setError(null)
+    setCurrentCategory(category)
+    setSearchQuery('')
+    setSidebarHidden(false)
+
+    try {
+      const terms = CATEGORY_TERMS[category] || WEIRD_TERMS
+      const selectedTerms = pickRandom(terms, 2)
+      const searchResults = await Promise.all(selectedTerms.map(t => searchYouTube(t, 15)))
+
+      const seen = new Set<string>()
+      const all: Video[] = []
+
+      searchResults.forEach(results => {
+        results.forEach(v => {
+          if (v.videoId && !seen.has(v.videoId)) {
+            seen.add(v.videoId)
+            all.push({
+              id: v.videoId,
+              title: v.title,
+              thumbnail: v.thumbnail,
+              viewCount: v.viewCount,
+              publishedAt: v.publishedAt,
+            })
+          }
+        })
+      })
+
+      all.sort((a, b) => (a.viewCount || 0) - (b.viewCount || 0))
+      setResults(all)
+      setCurrentPage(1)
+      setTotalPages(Math.ceil(all.length / ITEMS_PER_PAGE))
+      setLoading(false)
+      setStatusText(`${all.length} fragments in ${categoryName}`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+      setLoading(false)
+    }
+  }, [searchYouTube])
+
+  const doSearch = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault()
+    const q = searchQuery.trim()
+    if (!q) return
+
+    setLoading(true)
+    setLoadingMessage('EXECUTING SEARCH QUERY...')
+    setStatusText('Executing search query...')
+    setError(null)
+    setCurrentCategory(null)
+    setSidebarHidden(true)
+
+    try {
+      const searchResults = await searchYouTube(q, 50)
+      const videos: Video[] = searchResults.map(v => ({
+        id: v.videoId,
+        title: v.title,
+        thumbnail: v.thumbnail,
+        viewCount: v.viewCount,
+        publishedAt: v.publishedAt,
+      }))
+
+      setResults(videos)
+      setCurrentPage(1)
+      setTotalPages(Math.ceil(videos.length / ITEMS_PER_PAGE))
+      setLoading(false)
+      setStatusText(`Scan complete: ${videos.length} matches`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+      setLoading(false)
+    }
+  }, [searchQuery, searchYouTube])
+
+  const loadPlaylists = useCallback(async () => {
+    if (!playlistService) return
+
+    setLoading(true)
+    setLoadingMessage('ACCESSING PLAYLIST DATABASE...')
+    setStatusText('Connecting to storage...')
+    setError(null)
+
+    try {
+      await playlistService.loadFromServer()
+      const lists = playlistService.getPlaylists()
+      setPlaylists(lists)
+      setLoading(false)
+      setStatusText(`${lists.length} archives mounted`)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error')
+      setLoading(false)
+    }
+  }, [playlistService])
+
+  const createPlaylist = useCallback(async () => {
+    if (!playlistService) return
+
+    const name = window.prompt('Archive designation:')
+    if (!name?.trim()) return
+
+    setStatusText('Initializing archive...')
+    try {
+      playlistService.createPlaylist(name.trim())
+      await loadPlaylists()
+      setStatusText('Archive created')
+    } catch (err) {
+      alert(`Archive initialization failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
+      setStatusText('Creation failed')
+    }
+  }, [playlistService, loadPlaylists])
+
+  const deletePlaylist = useCallback(async (id: string) => {
+    if (!playlistService) return
+    if (!window.confirm('Permanently purge this archive?')) return
+
+    setStatusText('Purging archive...')
+    try {
+      playlistService.removePlaylist(id)
+      await loadPlaylists()
+      setStatusText('Archive purged')
+    } catch (err) {
+      alert(`Purge failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
+      setStatusText('Purge failed')
+    }
+  }, [playlistService, loadPlaylists])
+
+  const openPlaylist = useCallback((pl: Playlist) => {
+    setCurrentPlaylist(pl)
+    setView('playlist-detail')
+    setStatusText(`${pl.items.length} fragments in archive`)
+  }, [])
+
+  const removeFromPlaylist = useCallback(async (playlistId: string, videoId: string) => {
+    if (!playlistService || !currentPlaylist) return
+
+    setStatusText('Modifying archive...')
+    try {
+      playlistService.removeTrack(playlistId, videoId)
+      const updated = { ...currentPlaylist, items: currentPlaylist.items.filter(v => v.id !== videoId) }
+      setCurrentPlaylist(updated)
+      setStatusText('Fragment removed')
+    } catch (err) {
+      alert(`Modification failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
+      setStatusText('Operation failed')
+    }
+  }, [playlistService, currentPlaylist])
+
+  const watchVideo = useCallback((video: Video) => {
+    setCurrentVideo(video)
+    setView('watch')
+    setStatusText('SIGNAL ACQUIRED')
+  }, [])
+
+  const watchTrack = useCallback((track: PlaylistTrack) => {
+    const ytId = extractYouTubeId(track)
+    setCurrentVideo({
+      id: ytId,
+      title: track.title,
+    })
+    setView('watch')
+    setStatusText('SIGNAL ACQUIRED')
+  }, [])
+
+  const addCurrentToPlaylist = useCallback(async () => {
+    if (!currentVideo || !playlistService) return
+
+    setStatusText('Processing...')
+
+    try {
+      const lists = playlistService.getPlaylists()
+
+      if (lists.length === 0) {
+        const createNew = window.confirm('No archives exist. Initialize new container?')
+        if (!createNew) {
+          setStatusText('Operation cancelled')
+          return
+        }
+
+        const name = window.prompt('Archive designation:')
+        if (!name?.trim()) {
+          setStatusText('Operation cancelled')
+          return
+        }
+
+        const newPl: Playlist = {
+          id: crypto.randomUUID(),
+          name: name.trim(),
+          items: [{
+            id: currentVideo.id,
+            title: currentVideo.title,
+            link: `https://www.youtube.com/watch?v=${currentVideo.id}`,
+            duration: 0,
+          }],
+        }
+
+        playlistService.createPlaylist(newPl.name)
+        playlistService.addTrack(newPl.id, newPl.items[0]!)
+        alert(`Fragment stored in "${name.trim()}"`)
+        setStatusText('Stored successfully')
+        return
+      }
+
+      const options = lists.map((pl, i) => `${i + 1}. ${pl.name}`).join('\n')
+      const choice = window.prompt(`Select destination archive:\n${options}\n\nEnter number:`)
+
+      if (!choice) {
+        setStatusText('Operation cancelled')
+        return
+      }
+
+      const idx = parseInt(choice, 10) - 1
+      if (isNaN(idx) || idx < 0 || idx >= lists.length) {
+        alert('Invalid selection.')
+        setStatusText('Invalid selection')
+        return
+      }
+
+      const pl = lists[idx]!
+      const track: PlaylistTrack = {
+        id: currentVideo.id,
+        title: currentVideo.title,
+        link: `https://www.youtube.com/watch?v=${currentVideo.id}`,
+        duration: 0,
+      }
+
+      playlistService.addTrack(pl.id, track)
+      alert(`Fragment stored in "${pl.name}"`)
+      setStatusText('Stored successfully')
+    } catch (err) {
+      alert(`Storage failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
+      setStatusText('Storage failed')
+    }
+  }, [currentVideo, playlistService])
+
+  const goBack = useCallback(() => {
+    if (view === 'watch') {
+      if (currentPlaylist) {
+        setView('playlist-detail')
+      } else if (currentCategory) {
+        setView('homepage')
+      } else {
+        setView('homepage')
+      }
+    } else if (view === 'playlist-detail') {
+      setView('playlists')
+      setCurrentPlaylist(null)
+    }
+  }, [view, currentPlaylist, currentCategory])
+
+  const showView = useCallback((v: View) => {
+    setView(v)
+    if (v === 'homepage') {
+      setCurrentCategory(null)
+      setSearchQuery('')
+      setSidebarHidden(false)
+      loadHomepage()
+    } else if (v === 'playlists') {
+      setCurrentCategory(null)
+      setSearchQuery('')
+      setSidebarHidden(false)
+      loadPlaylists()
+    }
+  }, [loadHomepage, loadPlaylists])
+
+  useEffect(() => {
+    loadHomepage()
+  }, [loadHomepage])
+
+  const paginatedResults = useMemo(() => {
+    const start = (currentPage - 1) * ITEMS_PER_PAGE
+    return results.slice(start, start + ITEMS_PER_PAGE)
+  }, [results, currentPage])
+
+  const corruptionLevel = useMemo(() => Math.floor(Math.random() * 87 + 13), [])
+  const signalStrength = useMemo(() => Math.floor(Math.random() * 40 + 60), [])
+  const distortion = useMemo(() => (Math.random() * 15).toFixed(1), [])
+
+  return (
+    <div className="mt-root">
+      {/* Header */}
+      <div id="mt-header">
+        <div className="logo">MUTANT</div>
+        <form id="mt-search-form" onSubmit={doSearch}>
+          <input
+            id="mt-search-input"
+            type="text"
+            placeholder="SEARCH ARCHIVES..."
+            autoComplete="off"
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+          />
+          <button type="submit" id="mt-search-btn">
+            <span className="btn-skull">💀</span>
+            <span>SEARCH</span>
+          </button>
+        </form>
+        <div className="header-status">
+          <div className="status-item">
+            <div className="status-indicator" />
+            <span>SYSTEM: ONLINE</span>
+          </div>
+          <div className="status-item">
+            <span>INTEGRITY: 87%</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div id="mt-tabs">
+        <button
+          className={`mt-tab${view === 'homepage' || view === 'watch' ? ' active' : ''}`}
+          onClick={() => showView('homepage')}
+        >
+          Home
+        </button>
+        <button
+          className={`mt-tab${view === 'playlists' || view === 'playlist-detail' ? ' active' : ''}`}
+          onClick={() => showView('playlists')}
+        >
+          Playlists
+        </button>
+      </div>
+
+      {/* Main */}
+      <div id="mt-main">
+        {/* Sidebar */}
+        <div id={`mt-sidebar${sidebarHidden ? ' hidden' : ''}`}>
+          <h3>Directories</h3>
+          {Object.entries(CATEGORY_TERMS).map(([key]) => (
+            <div
+              key={key}
+              className={`directory-item${currentCategory === key ? ' active' : ''}`}
+              onClick={() => loadCategory(key, key.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase()))}
+            >
+              {key.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase())}
+            </div>
+          ))}
+        </div>
+
+        {/* Content */}
+        <div id="mt-content">
+          {loading && (
+            <div className="loading-container">
+              <div className="loading-skull">💀</div>
+              <div className="loading-text">DECRYPTING ARCHIVE</div>
+              <div className="loading-progress">
+                <div className="loading-progress-bar" />
+              </div>
+              <div className="loading-status">{loadingMessage}</div>
+            </div>
+          )}
+
+          {error && (
+            <div id="mt-error">Error: {error}</div>
+          )}
+
+          {!loading && !error && view === 'homepage' && (
+            <>
+              <div className="section-title">
+                ⚠ FRAGMENTED SIGNALS DETECTED ⚠
+              </div>
+              {results.length === 0 ? (
+                <div className="empty-state">
+                  No signals detected.<br />Initialize manual search.
+                </div>
+              ) : (
+                <>
+                  <div className="mt-masonry">
+                    {paginatedResults.map((v, i) => (
+                      <div
+                        key={v.id}
+                        className="mt-video-card"
+                        onClick={() => watchVideo(v)}
+                      >
+                        <div className="mt-thumb-container">
+                          {v.thumbnail ? (
+                            <img className="mt-thumb" src={v.thumbnail} alt="" loading="lazy" />
+                          ) : (
+                            <div className="mt-thumb-placeholder">▶</div>
+                          )}
+                        </div>
+                        <div className="mt-video-info">
+                          <div className="mt-video-title" data-index={i}>{v.title}</div>
+                          <div className="mt-video-meta">
+                            <span>{v.viewCount?.toLocaleString() ?? '???'}</span> VIEWS // {v.publishedAt ? formatTimeAgo(v.publishedAt) : 'UNKNOWN DATE'}
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                  {totalPages > 1 && (
+                    <div className="pagination">
+                      <button
+                        className="pagination-btn"
+                        onClick={() => setCurrentPage(p => Math.max(1, p - 1))}
+                        disabled={currentPage <= 1}
+                      >
+                        &lt; PREV
+                      </button>
+                      <div className="pagination-info">
+                        PAGE <span>{currentPage}</span> / <span>{totalPages}</span> // {results.length} FRAGMENTS
+                      </div>
+                      <button
+                        className="pagination-btn"
+                        onClick={() => setCurrentPage(p => Math.min(totalPages, p + 1))}
+                        disabled={currentPage >= totalPages}
+                      >
+                        NEXT &gt;
+                      </button>
+                    </div>
+                  )}
+                </>
+              )}
+            </>
+          )}
+
+          {!loading && !error && view === 'playlists' && (
+            <>
+              <div className="section-title">⚠ DATA ARCHIVES ⚠</div>
+              <button className="mt-btn-new" onClick={createPlaylist}>
+                + Initialize New Archive
+              </button>
+              {playlists.length === 0 ? (
+                <div className="empty-state">
+                  No archives found.<br />Create a new data container.
+                </div>
+              ) : (
+                playlists.map(pl => (
+                  <div
+                    key={pl.id}
+                    className="mt-playlist-item"
+                    onClick={() => openPlaylist(pl)}
+                  >
+                    <div className="mt-playlist-info">
+                      <div className="mt-playlist-name">[ {pl.name} ]</div>
+                      <div className="mt-playlist-count">{pl.items.length} FRAGMENTS STORED</div>
+                    </div>
+                    <button
+                      className="mt-btn-delete"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        deletePlaylist(pl.id)
+                      }}
+                    >
+                      PURGE
+                    </button>
+                  </div>
+                ))
+              )}
+            </>
+          )}
+
+          {!loading && !error && view === 'playlist-detail' && currentPlaylist && (
+            <>
+              <button className="mt-btn-back" onClick={goBack}>
+                ← RETURN TO ARCHIVES
+              </button>
+              <div className="section-title">ARCHIVE: [ {currentPlaylist.name} ]</div>
+              {currentPlaylist.items.length === 0 ? (
+                <div className="empty-state">
+                  Empty archive.<br />Consume media to populate.
+                </div>
+              ) : (
+                currentPlaylist.items.map(v => {
+                  const ytId = extractYouTubeId(v)
+                  return (
+                    <div
+                      key={v.id}
+                      className="mt-track-item"
+                      onClick={() => watchTrack(v)}
+                    >
+                      <span className="mt-track-title">▶ {v.title || ytId}</span>
+                      <button
+                        className="mt-btn-delete"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          removeFromPlaylist(currentPlaylist.id, v.id)
+                        }}
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  )
+                })
+              )}
+            </>
+          )}
+
+          {!loading && !error && view === 'watch' && currentVideo && (
+            <div id="mt-watch">
+              <button className="back-btn" onClick={goBack}>
+                ← RETURN TO ARCHIVE
+              </button>
+              <div id="mt-watch-frame-container">
+                <div className="corner-decoration corner-tl" />
+                <div className="corner-decoration corner-tr" />
+                <div className="corner-decoration corner-bl" />
+                <div className="corner-decoration corner-br" />
+                <div className="video-warning">⚠ LIVE FEED</div>
+                <div className="video-scanlines" />
+                <iframe
+                  id="mt-watch-frame"
+                  src={`https://www.youtube-nocookie.com/embed/${currentVideo.id}?autoplay=1`}
+                  allowFullScreen
+                />
+              </div>
+              <div id="mt-watch-info">
+                <div id="mt-watch-title">&gt; {currentVideo.title}</div>
+                <div className="video-stats">
+                  <div className="stat-item">
+                    <div className="stat-label">Signal Strength</div>
+                    <div className="stat-value">{signalStrength}%</div>
+                  </div>
+                  <div className="stat-item">
+                    <div className="stat-label">Data Corruption</div>
+                    <div className="stat-value">{corruptionLevel}%</div>
+                  </div>
+                  <div className="stat-item">
+                    <div className="stat-label">Distortion</div>
+                    <div className="stat-value">{distortion}dB</div>
+                  </div>
+                  <div className="stat-item">
+                    <div className="stat-label">Source</div>
+                    <div className="stat-value">EXTERNAL</div>
+                  </div>
+                </div>
+                <div id="mt-watch-actions">
+                  <button className="action-btn primary" onClick={addCurrentToPlaylist}>
+                    💀 STORE TO ARCHIVE
+                  </button>
+                  <button
+                    className="action-btn"
+                    onClick={() => {
+                      navigator.clipboard.writeText(`https://youtube.com/watch?v=${currentVideo.id}`)
+                      alert('Link copied to clipboard')
+                    }}
+                  >
+                    📋 COPY LINK
+                  </button>
+                </div>
+              </div>
+              <div className="glitch-decoration" style={{ top: '20%', left: '5%' }}>
+                ERR_{Math.floor(Math.random() * 999)}
+              </div>
+              <div className="glitch-decoration" style={{ top: '60%', right: '8%', animationDelay: '1s' }}>
+                SIG_LOSS
+              </div>
+              <div className="glitch-decoration" style={{ bottom: '30%', left: '10%', animationDelay: '2s' }}>
+                ◈ DATA ◈
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Status Bar */}
+      <div id="mt-status-bar">
+        <div className="status-text">{statusText}</div>
+        <div className="equalizer">
+          {[...Array(10)].map((_, i) => (
+            <div key={i} className="eq-bar" />
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/konpyuuta/src/components/apps/MutantTube.tsx
+++ b/packages/konpyuuta/src/components/apps/MutantTube.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useKonpyuuTA } from '../../context/KonpyuuTAContext'
 import type { Playlist, PlaylistTrack } from '../../types'
+import { usePopup } from './MutantTubePopup'
 
 type View = 'homepage' | 'playlists' | 'watch' | 'playlist-detail'
 
@@ -91,10 +92,11 @@ function extractYouTubeId(item: PlaylistTrack): string {
 
 export function MutantTube() {
   const { playlistService, env } = useKonpyuuTA()
+  const popup = usePopup()
 
   const [view, setView] = useState<View>('homepage')
   const [loading, setLoading] = useState(true)
-  const [loadingMessage, setLoadingMessage] = useState('INITIALIZING ARCHIVE...')
+  const [loadingMessage, setLoadingMessage] = useState('INITIALIZING...')
   const [error, setError] = useState<string | null>(null)
 
   const [searchQuery, setSearchQuery] = useState('')
@@ -131,7 +133,7 @@ export function MutantTube() {
 
   const loadHomepage = useCallback(async () => {
     setLoading(true)
-    setLoadingMessage('SCANNING ARCHIVES...')
+    setLoadingMessage('LOADING...')
     setStatusText('Retrieving data fragments...')
     setError(null)
 
@@ -172,7 +174,7 @@ export function MutantTube() {
 
   const loadCategory = useCallback(async (category: string, categoryName: string) => {
     setLoading(true)
-    setLoadingMessage('DECRYPTING ARCHIVE...')
+    setLoadingMessage('LOADING...')
     setStatusText('Decrypting category data...')
     setError(null)
     setCurrentCategory(category)
@@ -260,7 +262,7 @@ export function MutantTube() {
       const lists = playlistService.getPlaylists()
       setPlaylists(lists)
       setLoading(false)
-      setStatusText(`${lists.length} archives mounted`)
+      setStatusText(`${lists.length} playlists loaded`)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Unknown error')
       setLoading(false)
@@ -270,55 +272,56 @@ export function MutantTube() {
   const createPlaylist = useCallback(async () => {
     if (!playlistService) return
 
-    const name = window.prompt('Archive designation:')
+    const name = await popup.prompt('Enter playlist name:', '', 'Playlist name...', 'Create Playlist')
     if (!name?.trim()) return
 
-    setStatusText('Initializing archive...')
+    setStatusText('Creating playlist...')
     try {
       playlistService.createPlaylist(name.trim())
       await loadPlaylists()
-      setStatusText('Archive created')
+      setStatusText('Playlist created')
     } catch (err) {
-      alert(`Archive initialization failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
+      await popup.alert(`Failed to create playlist: ${err instanceof Error ? err.message : 'Unknown error'}`, 'Error')
       setStatusText('Creation failed')
     }
-  }, [playlistService, loadPlaylists])
+  }, [playlistService, loadPlaylists, popup])
 
   const deletePlaylist = useCallback(async (id: string) => {
     if (!playlistService) return
-    if (!window.confirm('Permanently purge this archive?')) return
+    const confirmed = await popup.confirm('Delete this playlist?', 'Confirm Delete')
+    if (!confirmed) return
 
-    setStatusText('Purging archive...')
+    setStatusText('Deleting playlist...')
     try {
       playlistService.removePlaylist(id)
       await loadPlaylists()
-      setStatusText('Archive purged')
+      setStatusText('Playlist deleted')
     } catch (err) {
-      alert(`Purge failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
-      setStatusText('Purge failed')
+      await popup.alert(`Failed to delete playlist: ${err instanceof Error ? err.message : 'Unknown error'}`, 'Error')
+      setStatusText('Delete failed')
     }
-  }, [playlistService, loadPlaylists])
+  }, [playlistService, loadPlaylists, popup])
 
   const openPlaylist = useCallback((pl: Playlist) => {
     setCurrentPlaylist(pl)
     setView('playlist-detail')
-    setStatusText(`${pl.items.length} fragments in archive`)
+    setStatusText(`${pl.items.length} videos in playlist`)
   }, [])
 
   const removeFromPlaylist = useCallback(async (playlistId: string, videoId: string) => {
     if (!playlistService || !currentPlaylist) return
 
-    setStatusText('Modifying archive...')
+    setStatusText('Removing from playlist...')
     try {
       playlistService.removeTrack(playlistId, videoId)
       const updated = { ...currentPlaylist, items: currentPlaylist.items.filter(v => v.id !== videoId) }
       setCurrentPlaylist(updated)
-      setStatusText('Fragment removed')
+      setStatusText('Removed from playlist')
     } catch (err) {
-      alert(`Modification failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
+      await popup.alert(`Failed to remove: ${err instanceof Error ? err.message : 'Unknown error'}`, 'Error')
       setStatusText('Operation failed')
     }
-  }, [playlistService, currentPlaylist])
+  }, [playlistService, currentPlaylist, popup])
 
   const watchVideo = useCallback((video: Video) => {
     setCurrentVideo(video)
@@ -345,13 +348,13 @@ export function MutantTube() {
       const lists = playlistService.getPlaylists()
 
       if (lists.length === 0) {
-        const createNew = window.confirm('No archives exist. Initialize new container?')
+        const createNew = await popup.confirm('No playlists exist. Create a new one?', 'Add to Playlist')
         if (!createNew) {
           setStatusText('Operation cancelled')
           return
         }
 
-        const name = window.prompt('Archive designation:')
+        const name = await popup.prompt('Enter playlist name:', '', 'Playlist name...', 'Create Playlist')
         if (!name?.trim()) {
           setStatusText('Operation cancelled')
           return
@@ -370,27 +373,26 @@ export function MutantTube() {
 
         playlistService.createPlaylist(newPl.name)
         playlistService.addTrack(newPl.id, newPl.items[0]!)
-        alert(`Fragment stored in "${name.trim()}"`)
-        setStatusText('Stored successfully')
+        await popup.alert(`Added to "${name.trim()}"`, 'Success')
+        setStatusText('Added to playlist')
         return
       }
 
-      const options = lists.map((pl, i) => `${i + 1}. ${pl.name}`).join('\n')
-      const choice = window.prompt(`Select destination archive:\n${options}\n\nEnter number:`)
+      const options = lists.map((pl) => ({ label: pl.name, value: pl.id }))
+      const selectedId = await popup.select('Select playlist:', options, lists[0]!.id, 'Add to Playlist')
 
-      if (!choice) {
+      if (!selectedId) {
         setStatusText('Operation cancelled')
         return
       }
 
-      const idx = parseInt(choice, 10) - 1
-      if (isNaN(idx) || idx < 0 || idx >= lists.length) {
-        alert('Invalid selection.')
+      const pl = lists.find((l) => l.id === selectedId)
+      if (!pl) {
+        await popup.alert('Invalid selection.', 'Error')
         setStatusText('Invalid selection')
         return
       }
 
-      const pl = lists[idx]!
       const track: PlaylistTrack = {
         id: currentVideo.id,
         title: currentVideo.title,
@@ -399,13 +401,13 @@ export function MutantTube() {
       }
 
       playlistService.addTrack(pl.id, track)
-      alert(`Fragment stored in "${pl.name}"`)
-      setStatusText('Stored successfully')
+      await popup.alert(`Added to "${pl.name}"`, 'Success')
+      setStatusText('Added to playlist')
     } catch (err) {
-      alert(`Storage failed: ${err instanceof Error ? err.message : 'Unknown error'}`)
-      setStatusText('Storage failed')
+      await popup.alert(`Failed to add: ${err instanceof Error ? err.message : 'Unknown error'}`, 'Error')
+      setStatusText('Add failed')
     }
-  }, [currentVideo, playlistService])
+  }, [currentVideo, playlistService, popup])
 
   const goBack = useCallback(() => {
     if (view === 'watch') {
@@ -452,20 +454,20 @@ export function MutantTube() {
 
   return (
     <div className="mt-root">
+      {popup.PopupComponent}
       {/* Header */}
       <div id="mt-header">
-        <div className="logo">MUTANT</div>
+        <div className="logo"></div>
         <form id="mt-search-form" onSubmit={doSearch}>
           <input
             id="mt-search-input"
             type="text"
-            placeholder="SEARCH ARCHIVES..."
+            placeholder="SEARCH VIDEOS..."
             autoComplete="off"
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
           />
           <button type="submit" id="mt-search-btn">
-            <span className="btn-skull">💀</span>
             <span>SEARCH</span>
           </button>
         </form>
@@ -516,8 +518,8 @@ export function MutantTube() {
         <div id="mt-content">
           {loading && (
             <div className="loading-container">
-              <div className="loading-skull">💀</div>
-              <div className="loading-text">DECRYPTING ARCHIVE</div>
+              <div className="loading-pulse">◈</div>
+              <div className="loading-text">LOADING</div>
               <div className="loading-progress">
                 <div className="loading-progress-bar" />
               </div>
@@ -591,13 +593,13 @@ export function MutantTube() {
 
           {!loading && !error && view === 'playlists' && (
             <>
-              <div className="section-title">⚠ DATA ARCHIVES ⚠</div>
+              <div className="section-title">⚠ PLAYLISTS ⚠</div>
               <button className="mt-btn-new" onClick={createPlaylist}>
-                + Initialize New Archive
+                + Create Playlist
               </button>
               {playlists.length === 0 ? (
                 <div className="empty-state">
-                  No archives found.<br />Create a new data container.
+                  No playlists found.<br />Create a new playlist.
                 </div>
               ) : (
                 playlists.map(pl => (
@@ -628,12 +630,12 @@ export function MutantTube() {
           {!loading && !error && view === 'playlist-detail' && currentPlaylist && (
             <>
               <button className="mt-btn-back" onClick={goBack}>
-                ← RETURN TO ARCHIVES
+                ← RETURN TO PLAYLISTS
               </button>
-              <div className="section-title">ARCHIVE: [ {currentPlaylist.name} ]</div>
+              <div className="section-title">PLAYLIST: [ {currentPlaylist.name} ]</div>
               {currentPlaylist.items.length === 0 ? (
                 <div className="empty-state">
-                  Empty archive.<br />Consume media to populate.
+                  Empty playlist.<br />Add videos to populate.
                 </div>
               ) : (
                 currentPlaylist.items.map(v => {
@@ -664,7 +666,7 @@ export function MutantTube() {
           {!loading && !error && view === 'watch' && currentVideo && (
             <div id="mt-watch">
               <button className="back-btn" onClick={goBack}>
-                ← RETURN TO ARCHIVE
+                ← RETURN
               </button>
               <div id="mt-watch-frame-container">
                 <div className="corner-decoration corner-tl" />
@@ -701,16 +703,16 @@ export function MutantTube() {
                 </div>
                 <div id="mt-watch-actions">
                   <button className="action-btn primary" onClick={addCurrentToPlaylist}>
-                    💀 STORE TO ARCHIVE
+                    ADD TO PLAYLIST
                   </button>
                   <button
                     className="action-btn"
-                    onClick={() => {
+                    onClick={async () => {
                       navigator.clipboard.writeText(`https://youtube.com/watch?v=${currentVideo.id}`)
-                      alert('Link copied to clipboard')
+                      await popup.alert('Link copied to clipboard', 'Copied')
                     }}
                   >
-                    📋 COPY LINK
+                    COPY LINK
                   </button>
                 </div>
               </div>

--- a/packages/konpyuuta/src/components/apps/MutantTubePopup.tsx
+++ b/packages/konpyuuta/src/components/apps/MutantTubePopup.tsx
@@ -1,0 +1,247 @@
+import { useState, useEffect, useCallback, useRef } from 'react'
+
+export type PopupType = 'alert' | 'confirm' | 'prompt' | 'select'
+
+export interface PopupOption {
+  label: string
+  value: string
+}
+
+export interface PopupProps {
+  isOpen: boolean
+  type: PopupType
+  title?: string
+  message?: string
+  placeholder?: string
+  defaultValue?: string
+  options?: PopupOption[]
+  onConfirm: (value?: string) => void
+  onCancel: () => void
+}
+
+export function MutantTubePopup({
+  isOpen,
+  type,
+  title,
+  message,
+  placeholder,
+  defaultValue,
+  options,
+  onConfirm,
+  onCancel,
+}: PopupProps) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const selectRef = useRef<HTMLSelectElement>(null)
+
+  useEffect(() => {
+    if (isOpen && inputRef.current) {
+      inputRef.current.focus()
+      inputRef.current.select()
+    }
+  }, [isOpen])
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        if (type === 'prompt') {
+          onConfirm(inputRef.current?.value ?? '')
+        } else if (type === 'select') {
+          onConfirm(selectRef.current?.value ?? '')
+        } else {
+          onConfirm()
+        }
+      } else if (e.key === 'Escape') {
+        e.preventDefault()
+        onCancel()
+      }
+    },
+    [type, onConfirm, onCancel]
+  )
+
+  const handleConfirm = useCallback(() => {
+    if (type === 'prompt') {
+      onConfirm(inputRef.current?.value ?? '')
+    } else if (type === 'select') {
+      onConfirm(selectRef.current?.value ?? '')
+    } else {
+      onConfirm()
+    }
+  }, [type, onConfirm])
+
+  if (!isOpen) return null
+
+  return (
+    <div className="mt-popup-overlay" onClick={onCancel}>
+      <div className="mt-popup" onClick={(e) => e.stopPropagation()} onKeyDown={handleKeyDown}>
+        <div className="mt-popup-corner mt-popup-corner-tl" />
+        <div className="mt-popup-corner mt-popup-corner-tr" />
+        <div className="mt-popup-corner mt-popup-corner-bl" />
+        <div className="mt-popup-corner mt-popup-corner-br" />
+
+        {title && (
+          <div className="mt-popup-header">
+            <span className="mt-popup-title">{title}</span>
+          </div>
+        )}
+
+        <div className="mt-popup-content">
+          {message && <div className="mt-popup-message">{message}</div>}
+
+          {type === 'prompt' && (
+            <input
+              ref={inputRef}
+              type="text"
+              className="mt-popup-input"
+              placeholder={placeholder}
+              defaultValue={defaultValue}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  e.preventDefault()
+                  handleConfirm()
+                }
+              }}
+            />
+          )}
+
+          {type === 'select' && options && (
+            <select ref={selectRef} className="mt-popup-select" defaultValue={defaultValue}>
+              {options.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </select>
+          )}
+
+          <div className="mt-popup-actions">
+            {type === 'alert' ? (
+              <button className="mt-popup-btn mt-popup-btn-primary" onClick={handleConfirm}>
+                ACKNOWLEDGE
+              </button>
+            ) : (
+              <>
+                <button className="mt-popup-btn mt-popup-btn-secondary" onClick={onCancel}>
+                  ABORT
+                </button>
+                <button className="mt-popup-btn mt-popup-btn-primary" onClick={handleConfirm}>
+                  CONFIRM
+                </button>
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="mt-popup-scanlines" />
+      </div>
+    </div>
+  )
+}
+
+export function usePopup() {
+  const [state, setState] = useState<{
+    isOpen: boolean
+    type: PopupType
+    title?: string
+    message?: string
+    placeholder?: string
+    defaultValue?: string
+    options?: PopupOption[]
+    resolve: ((value: string | boolean) => void) | null
+  }>({
+    isOpen: false,
+    type: 'alert',
+    resolve: null,
+  })
+
+  const alert = useCallback((message: string, title?: string): Promise<void> => {
+    return new Promise((resolve) => {
+      setState({
+        isOpen: true,
+        type: 'alert',
+        title,
+        message,
+        resolve: () => resolve(),
+      })
+    })
+  }, [])
+
+  const confirm = useCallback((message: string, title?: string): Promise<boolean> => {
+    return new Promise((resolve) => {
+      setState({
+        isOpen: true,
+        type: 'confirm',
+        title,
+        message,
+        resolve: (value) => resolve(!!value),
+      })
+    })
+  }, [])
+
+  const prompt = useCallback(
+    (message: string, defaultValue?: string, placeholder?: string, title?: string): Promise<string | null> => {
+      return new Promise((resolve) => {
+        setState({
+          isOpen: true,
+          type: 'prompt',
+          title,
+          message,
+          placeholder,
+          defaultValue,
+          resolve: (value) => resolve(typeof value === 'string' ? value : null),
+        })
+      })
+    },
+    []
+  )
+
+  const select = useCallback(
+    (message: string, options: PopupOption[], defaultValue?: string, title?: string): Promise<string | null> => {
+      return new Promise((resolve) => {
+        setState({
+          isOpen: true,
+          type: 'select',
+          title,
+          message,
+          options,
+          defaultValue,
+          resolve: (value) => resolve(typeof value === 'string' ? value : null),
+        })
+      })
+    },
+    []
+  )
+
+  const handleConfirm = useCallback((value?: string) => {
+    state.resolve?.(value ?? true)
+    setState((s) => ({ ...s, isOpen: false, resolve: null }))
+  }, [state.resolve])
+
+  const handleCancel = useCallback(() => {
+    state.resolve?.(false)
+    setState((s) => ({ ...s, isOpen: false, resolve: null }))
+  }, [state.resolve])
+
+  const PopupComponent = (
+    <MutantTubePopup
+      isOpen={state.isOpen}
+      type={state.type}
+      title={state.title}
+      message={state.message}
+      placeholder={state.placeholder}
+      defaultValue={state.defaultValue}
+      options={state.options}
+      onConfirm={handleConfirm}
+      onCancel={handleCancel}
+    />
+  )
+
+  return {
+    alert,
+    confirm,
+    prompt,
+    select,
+    PopupComponent,
+  }
+}
+

--- a/packages/konpyuuta/src/stores/desktopStore.ts
+++ b/packages/konpyuuta/src/stores/desktopStore.ts
@@ -22,6 +22,9 @@ const DEFAULT_ICONS: DesktopIcon[] = [
   { id: 'netscape', label: 'Netscape', icon: '/icons/apps/netscape_classic.png', app: 'netscape' },
   { id: 'lynx', label: 'Lynx', icon: '/icons/apps/Lynx.svg', app: 'lynx' },
   { id: 'mutanttube', label: 'MutantTube', icon: '/icons/apps/mutanttube.svg', app: 'mutanttube' },
+  { id: 'mutantbook', label: 'MutantBook', icon: '/icons/apps/mutantbook.svg', app: 'mutantbook' },
+  { id: 'messenger', label: 'Messenger', icon: '/icons/apps/messenger.svg', app: 'messenger' },
+  { id: 'mutantmail', label: 'MutantMail', icon: '/icons/apps/mutantmail.svg', app: 'mutantmail' },
   { id: 'settings', label: 'Style Manager', icon: '/icons/apps/org.xfce.settings.manager.png', app: 'settings' },
   { id: 'filemanager', label: 'File Manager', icon: '/icons/apps/filemanager.png', app: 'filemanager' },
 ]

--- a/packages/konpyuuta/src/stores/desktopStore.ts
+++ b/packages/konpyuuta/src/stores/desktopStore.ts
@@ -21,6 +21,7 @@ interface DesktopStoreState {
 const DEFAULT_ICONS: DesktopIcon[] = [
   { id: 'netscape', label: 'Netscape', icon: '/icons/apps/netscape_classic.png', app: 'netscape' },
   { id: 'lynx', label: 'Lynx', icon: '/icons/apps/Lynx.svg', app: 'lynx' },
+  { id: 'mutanttube', label: 'MutantTube', icon: '/icons/apps/mutanttube.svg', app: 'mutanttube' },
   { id: 'settings', label: 'Style Manager', icon: '/icons/apps/org.xfce.settings.manager.png', app: 'settings' },
   { id: 'filemanager', label: 'File Manager', icon: '/icons/apps/filemanager.png', app: 'filemanager' },
 ]

--- a/packages/konpyuuta/src/stores/mailStore.ts
+++ b/packages/konpyuuta/src/stores/mailStore.ts
@@ -1,0 +1,94 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+export type MailFolder = 'inbox' | 'sent' | 'drafts' | 'trash'
+
+export interface MailMessage {
+  id: string
+  from: string
+  to: string
+  subject: string
+  body: string
+  read: boolean
+  folder: MailFolder
+  createdAt: number
+}
+
+interface MailStoreState {
+  messages: MailMessage[]
+  selectedMessageId: string | null
+  currentFolder: MailFolder
+  composing: boolean
+
+  setMessages: (messages: MailMessage[]) => void
+  addMessage: (message: MailMessage) => void
+  removeMessage: (id: string) => void
+  setSelectedMessage: (id: string | null) => void
+  setCurrentFolder: (folder: MailFolder) => void
+  setComposing: (composing: boolean) => void
+  markAsRead: (id: string) => void
+  moveToTrash: (id: string) => void
+  getFolderMessages: (folder: MailFolder) => MailMessage[]
+  getUnreadCount: (folder: MailFolder) => number
+}
+
+export const useMailStore = create<MailStoreState>()(
+  persist(
+    (set, get) => ({
+      messages: [],
+      selectedMessageId: null,
+      currentFolder: 'inbox',
+      composing: false,
+
+      setMessages: (messages) => set({ messages }),
+
+      addMessage: (message) =>
+        set((state) => ({
+          messages: [message, ...state.messages],
+        })),
+
+      removeMessage: (id) =>
+        set((state) => ({
+          messages: state.messages.filter((m) => m.id !== id),
+          selectedMessageId: state.selectedMessageId === id ? null : state.selectedMessageId,
+        })),
+
+      setSelectedMessage: (id) => set({ selectedMessageId: id }),
+
+      setCurrentFolder: (folder) =>
+        set({
+          currentFolder: folder,
+          selectedMessageId: null,
+          composing: false,
+        }),
+
+      setComposing: (composing) => set({ composing }),
+
+      markAsRead: (id) =>
+        set((state) => ({
+          messages: state.messages.map((m) =>
+            m.id === id ? { ...m, read: true } : m
+          ),
+        })),
+
+      moveToTrash: (id) =>
+        set((state) => ({
+          messages: state.messages.map((m) =>
+            m.id === id ? { ...m, folder: 'trash' as MailFolder } : m
+          ),
+          selectedMessageId: state.selectedMessageId === id ? null : state.selectedMessageId,
+        })),
+
+      getFolderMessages: (folder) => {
+        return get().messages.filter((m) => m.folder === folder)
+      },
+
+      getUnreadCount: (folder) => {
+        return get().messages.filter((m) => m.folder === folder && !m.read).length
+      },
+    }),
+    {
+      name: 'konpyuuta-mail',
+    }
+  )
+)

--- a/packages/konpyuuta/src/stores/messengerStore.ts
+++ b/packages/konpyuuta/src/stores/messengerStore.ts
@@ -1,0 +1,96 @@
+import { create } from 'zustand'
+
+export interface Conversation {
+  channelId: string
+  userId: string
+  username: string
+  displayName: string
+  online: boolean
+  unread: number
+  lastMessage?: string
+  lastMessageAt?: number
+}
+
+export interface Message {
+  id: string
+  senderId: string
+  content: string
+  createdAt: number
+}
+
+interface MessengerStoreState {
+  conversations: Conversation[]
+  activeConversationId: string | null
+  messages: Record<string, Message[]>
+  typing: Record<string, boolean>
+  buddyListOpen: boolean
+
+  setConversations: (conversations: Conversation[]) => void
+  addConversation: (conv: Conversation) => void
+  setActiveConversation: (channelId: string | null) => void
+  addMessage: (channelId: string, message: Message) => void
+  setMessages: (channelId: string, messages: Message[]) => void
+  setTyping: (channelId: string, isTyping: boolean) => void
+  setBuddyListOpen: (open: boolean) => void
+  incrementUnread: (channelId: string) => void
+  clearUnread: (channelId: string) => void
+}
+
+export const useMessengerStore = create<MessengerStoreState>((set) => ({
+  conversations: [],
+  activeConversationId: null,
+  messages: {},
+  typing: {},
+  buddyListOpen: true,
+
+  setConversations: (conversations) => set({ conversations }),
+
+  addConversation: (conv) =>
+    set((state) => ({
+      conversations: state.conversations.some((c) => c.channelId === conv.channelId)
+        ? state.conversations
+        : [...state.conversations, conv],
+    })),
+
+  setActiveConversation: (channelId) => set({ activeConversationId: channelId }),
+
+  addMessage: (channelId, message) =>
+    set((state) => ({
+      messages: {
+        ...state.messages,
+        [channelId]: [...(state.messages[channelId] || []), message],
+      },
+    })),
+
+  setMessages: (channelId, messages) =>
+    set((state) => ({
+      messages: {
+        ...state.messages,
+        [channelId]: messages,
+      },
+    })),
+
+  setTyping: (channelId, isTyping) =>
+    set((state) => ({
+      typing: {
+        ...state.typing,
+        [channelId]: isTyping,
+      },
+    })),
+
+  setBuddyListOpen: (open) => set({ buddyListOpen: open }),
+
+  incrementUnread: (channelId) =>
+    set((state) => ({
+      conversations: state.conversations.map((c) =>
+        c.channelId === channelId ? { ...c, unread: c.unread + 1 } : c
+      ),
+    })),
+
+  clearUnread: (channelId) =>
+    set((state) => ({
+      conversations: state.conversations.map((c) =>
+        c.channelId === channelId ? { ...c, unread: 0 } : c
+      ),
+    })),
+}))

--- a/packages/konpyuuta/src/styles/cde.css
+++ b/packages/konpyuuta/src/styles/cde.css
@@ -1,6 +1,4 @@
-/* KonpyuuTA — CDE React Component Styles
-   Faithful port of the original Debian CDE aesthetic.
-   Uses original variable names from variables.css for consistency. */
+@import url('https://fonts.googleapis.com/css2?family=Creepster&family=Nosifer&family=Rubik+Glitch&family=Share+Tech+Mono&display=swap');
 
 /* ── CSS Variables (matches original variables.css) ─────────────────────── */
 .cde-root {
@@ -3103,20 +3101,25 @@
    ═════════════════════════════════════════════════════════════════════════════ */
 
 .mt-root {
+  /* Bio-horror color palette - infected flesh, rot, veins, puss */
   --void-black: #0a0a0a;
-  --rust-orange: #B7410E;
-  --rust-dark: #8B4513;
-  --slime-green: #9ACD32;
-  --slime-dark: #556B2F;
+  --flesh-pink: #FF6B6B;
+  --flesh-rotten: #FFB4B4;
+  --rot-green: #4A6741;
+  --rot-slime: #8B9A46;
+  --vein-purple: #6B4E71;
+  --vein-dark: #8B6B8B;
+  --puss-yellow: #C4B454;
+  --puss-green: #D4C464;
+  --organ-red: #4A1C1C;
+  --organ-dark: #6B2D2D;
   --bone: #F5F5DC;
   --bone-dim: #C0C0C0;
-  --steel: #2F4F4F;
-  --steel-light: #4A6464;
-  --warning: #FFBF00;
-  --blood: #8B0000;
-  --panel-bg: #1a1a1a;
+  --infected-border: #8B0000;
+  --panel-bg: #1a0f0f;
+  --slime-green: #9ACD32;
 
-  font-family: 'Chakra Petch', sans-serif;
+  font-family: 'Share Tech Mono', monospace;
   font-size: 13px;
   background: var(--void-black);
   color: var(--bone);
@@ -3173,16 +3176,17 @@
 .mt-root .loading-container::before { top: 8px; left: 8px; }
 .mt-root .loading-container::after { bottom: 8px; right: 8px; }
 
-.mt-root .loading-skull {
+.mt-root .loading-pulse {
   font-size: 48px;
   margin-bottom: 16px;
-  animation: skull-pulse 1.2s ease-in-out infinite;
-  text-shadow: 0 0 20px rgba(183, 65, 14, 0.6);
+  animation: pulse-beat 1.2s ease-in-out infinite;
+  text-shadow: 0 0 20px rgba(255, 107, 107, 0.6);
+  color: var(--flesh-pink);
 }
 
-@keyframes skull-pulse {
+@keyframes pulse-beat {
   0%, 100% { transform: scale(1); filter: brightness(1); }
-  50% { transform: scale(1.08); filter: brightness(1.3); }
+  50% { transform: scale(1.15); filter: brightness(1.4); }
 }
 
 .mt-root .loading-text {
@@ -3284,26 +3288,60 @@
 .mt-root #mt-header::after { right: 8px; }
 
 .mt-root .logo { 
-  font-family: 'Share Tech Mono', monospace;
-  font-size: 24px; 
-  font-weight: 700;
-  letter-spacing: 2px;
-  color: var(--bone);
+  font-family: 'Creepster', cursive;
+  font-size: 42px; 
+  font-weight: 400;
+  letter-spacing: 6px;
+  color: var(--flesh-pink);
   text-shadow: 
-    0 0 10px rgba(183, 65, 14, 0.5),
-    2px 2px 0 var(--blood);
+    0 0 10px rgba(255, 107, 107, 0.8),
+    0 0 20px rgba(255, 107, 107, 0.5),
+    0 0 40px rgba(139, 0, 0, 0.4),
+    3px 3px 0 var(--organ-red),
+    -2px -2px 0 var(--rot-green);
   position: relative;
-  animation: logo-flicker 8s infinite;
+  animation: logo-flicker 4s infinite, logo-pulse 3s ease-in-out infinite, slime-drip 5s ease-in-out infinite;
+  background: linear-gradient(180deg, var(--flesh-pink) 0%, var(--flesh-rotten) 30%, var(--organ-red) 100%);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  filter: drop-shadow(0 0 12px rgba(255, 107, 107, 0.6)) drop-shadow(4px 4px 0 var(--organ-red));
+}
+
+.mt-root .logo::before {
+  content: 'TUBES';
+  position: relative;
 }
 
 .mt-root .logo::after {
-  content: '::ARCHIVE';
-  color: var(--rust-orange);
-  font-size: 12px;
+  content: '';
   position: absolute;
-  bottom: -4px;
-  right: 0;
-  letter-spacing: 1px;
+  bottom: -15px;
+  left: 10%;
+  width: 80%;
+  height: 12px;
+  background: linear-gradient(180deg, var(--flesh-pink) 0%, transparent 100%);
+  filter: blur(2px);
+  opacity: 0.7;
+  animation: slime-drip 3s ease-in-out infinite;
+}
+
+@keyframes slime-drip {
+  0%, 100% { 
+    height: 8px; 
+    opacity: 0.6;
+    transform: scaleY(1);
+  }
+  50% { 
+    height: 20px; 
+    opacity: 0.9;
+    transform: scaleY(1.3);
+  }
+}
+
+@keyframes logo-pulse {
+  0%, 100% { filter: drop-shadow(0 0 12px rgba(255, 107, 107, 0.6)) drop-shadow(4px 4px 0 var(--organ-red)); }
+  50% { filter: drop-shadow(0 0 20px rgba(255, 107, 107, 0.9)) drop-shadow(4px 4px 0 var(--organ-red)) drop-shadow(0 0 40px rgba(74, 103, 65, 0.5)); }
 }
 
 @keyframes logo-flicker {
@@ -3734,6 +3772,7 @@
   margin-bottom: 6px;
   display: -webkit-box;
   -webkit-line-clamp: 2;
+  line-clamp: 2;
   -webkit-box-orient: vertical;
   overflow: hidden;
   transition: color 0.2s;
@@ -3972,13 +4011,19 @@
 }
 
 .mt-root .action-btn.primary {
-  background: linear-gradient(180deg, var(--slime-dark) 0%, var(--slime-green) 100%);
-  border-color: var(--slime-green);
+  background: linear-gradient(180deg, var(--flesh-rotten) 0%, var(--flesh-pink) 100%);
+  border-color: var(--flesh-pink);
   color: var(--void-black);
+  font-weight: 700;
+  text-shadow: none;
+  box-shadow: 0 0 15px rgba(255, 107, 107, 0.3);
 }
 
 .mt-root .action-btn.primary:hover {
-  box-shadow: 0 0 20px rgba(154, 205, 50, 0.4);
+  background: linear-gradient(180deg, var(--flesh-pink) 0%, var(--organ-red) 100%);
+  border-color: var(--organ-red);
+  box-shadow: 0 0 25px rgba(255, 107, 107, 0.6);
+  transform: translateY(-2px);
 }
 
 /* Glitchy decorations */
@@ -4312,4 +4357,1364 @@
 
 .mt-root ::-webkit-scrollbar-thumb:hover {
   background: var(--rust-orange);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   POPUP / DIALOG
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-popup-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 10, 10, 0.85);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  animation: mt-overlay-fade-in 0.2s ease-out;
+}
+
+@keyframes mt-overlay-fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.mt-popup {
+  position: relative;
+  background: var(--panel-bg);
+  border: 3px solid var(--rust-orange);
+  box-shadow:
+    0 0 60px rgba(183, 65, 14, 0.4),
+    inset 0 0 40px rgba(0, 0, 0, 0.5);
+  min-width: 320px;
+  max-width: 90vw;
+  animation: mt-popup-appear 0.25s ease-out;
+}
+
+@keyframes mt-popup-appear {
+  from {
+    opacity: 0;
+    transform: scale(0.9) translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1) translateY(0);
+  }
+}
+
+.mt-popup-corner {
+  position: absolute;
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--slime-green);
+  z-index: 2;
+}
+
+.mt-popup-corner-tl { top: -3px; left: -3px; border-right: none; border-bottom: none; }
+.mt-popup-corner-tr { top: -3px; right: -3px; border-left: none; border-bottom: none; }
+.mt-popup-corner-bl { bottom: -3px; left: -3px; border-right: none; border-top: none; }
+.mt-popup-corner-br { bottom: -3px; right: -3px; border-left: none; border-top: none; }
+
+.mt-popup-corner::before {
+  content: '◉';
+  position: absolute;
+  font-size: 8px;
+  color: var(--rust-orange);
+}
+
+.mt-popup-corner-tl::before { top: 2px; left: 2px; }
+.mt-popup-corner-tr::before { top: 2px; right: 2px; }
+.mt-popup-corner-bl::before { bottom: 2px; left: 2px; }
+.mt-popup-corner-br::before { bottom: 2px; right: 2px; }
+
+.mt-popup-header {
+  background: linear-gradient(180deg, #2a2a2a 0%, var(--panel-bg) 100%);
+  border-bottom: 2px solid var(--steel);
+  padding: 12px 16px;
+  position: relative;
+}
+
+.mt-popup-title {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--slime-green);
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  text-shadow: 0 0 10px rgba(154, 205, 50, 0.5);
+}
+
+.mt-popup-title::before {
+  content: '◈ ';
+  color: var(--rust-orange);
+}
+
+.mt-popup-content {
+  padding: 20px;
+}
+
+.mt-popup-message {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 13px;
+  color: var(--bone);
+  line-height: 1.6;
+  margin-bottom: 16px;
+  white-space: pre-wrap;
+}
+
+.mt-popup-input {
+  width: 100%;
+  padding: 10px 14px;
+  background: #0f0f0f;
+  border: 2px solid var(--steel);
+  color: var(--bone);
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 13px;
+  outline: none;
+  transition: all 0.2s;
+  margin-bottom: 16px;
+}
+
+.mt-popup-input:focus {
+  border-color: var(--rust-orange);
+  box-shadow:
+    0 0 10px rgba(183, 65, 14, 0.3),
+    inset 0 0 20px rgba(183, 65, 14, 0.05);
+}
+
+.mt-popup-input::placeholder {
+  color: var(--steel);
+}
+
+.mt-popup-select {
+  width: 100%;
+  padding: 10px 14px;
+  background: #0f0f0f;
+  border: 2px solid var(--steel);
+  color: var(--bone);
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 13px;
+  outline: none;
+  cursor: pointer;
+  margin-bottom: 16px;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%239ACD32' d='M6 8L2 4h8z'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 12px center;
+}
+
+.mt-popup-select:focus {
+  border-color: var(--rust-orange);
+  box-shadow: 0 0 10px rgba(183, 65, 14, 0.3);
+}
+
+.mt-popup-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.mt-popup-btn {
+  padding: 10px 20px;
+  font-family: 'Chakra Petch', sans-serif;
+  font-size: 12px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  cursor: pointer;
+  transition: all 0.2s;
+  border: 2px solid;
+}
+
+.mt-popup-btn-primary {
+  background: linear-gradient(180deg, var(--slime-dark) 0%, var(--slime-green) 100%);
+  border-color: var(--slime-green);
+  color: var(--void-black);
+}
+
+.mt-popup-btn-primary:hover {
+  box-shadow: 0 0 20px rgba(154, 205, 50, 0.5);
+  transform: translateY(-2px);
+}
+
+.mt-popup-btn-secondary {
+  background: transparent;
+  border-color: var(--steel);
+  color: var(--bone-dim);
+}
+
+.mt-popup-btn-secondary:hover {
+  border-color: var(--blood);
+  color: var(--blood);
+  background: rgba(139, 0, 0, 0.1);
+}
+
+.mt-popup-scanlines {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0, 0, 0, 0.08) 2px,
+    rgba(0, 0, 0, 0.08) 4px
+  );
+  opacity: 0.5;
+}
+
+/* ── MutantBook (Facebook 2005-2007 style) ───────────────────────────────── */
+
+.mb-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #e9ebee;
+  font-family: 'Lucida Grande', Tahoma, Verdana, Arial, sans-serif;
+  font-size: 12px;
+  color: #1c1e21;
+}
+
+.mb-loading,
+.mb-error {
+  padding: 40px;
+  text-align: center;
+  color: #90949c;
+}
+
+.mb-error {
+  color: #cd201f;
+}
+
+/* Lookup bar */
+.mb-lookup {
+  display: flex;
+  gap: 6px;
+  padding: 8px;
+  background: #fff;
+  border-bottom: 1px solid #dddfe2;
+}
+
+.mb-back-btn {
+  background: none;
+  border: none;
+  color: #3b5998;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+}
+
+.mb-back-btn:hover {
+  text-decoration: underline;
+}
+
+.mb-lookup-input {
+  flex: 1;
+  padding: 4px 6px;
+  border: 1px solid #bdc7d8;
+  border-radius: 2px;
+  font-size: 11px;
+  font-family: inherit;
+  outline: none;
+}
+
+.mb-lookup-input:focus {
+  border-color: #3b5998;
+}
+
+.mb-lookup-btn {
+  padding: 4px 10px;
+  background: #5b74a8;
+  color: #fff;
+  border: 1px solid #29447e;
+  border-radius: 2px;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+}
+
+.mb-lookup-btn:hover {
+  background: #6d8bc4;
+}
+
+/* Profile header */
+.mb-header {
+  display: flex;
+  gap: 12px;
+  padding: 12px;
+  background: #3b5998;
+  color: #fff;
+}
+
+.mb-avatar {
+  width: 70px;
+  height: 70px;
+  background: #8b9dc3;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 28px;
+  font-weight: bold;
+  color: #fff;
+  flex-shrink: 0;
+  overflow: hidden;
+}
+
+.mb-avatar img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.mb-header-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.mb-name {
+  font-size: 16px;
+  font-weight: bold;
+}
+
+.mb-username {
+  font-size: 11px;
+  opacity: 0.8;
+  margin-top: 2px;
+}
+
+.mb-bio {
+  font-size: 11px;
+  opacity: 0.7;
+  margin-top: 4px;
+  font-style: italic;
+}
+
+.mb-header-actions {
+  margin-top: 8px;
+}
+
+.mb-friend-btn {
+  padding: 3px 10px;
+  background: #4267B2;
+  color: #fff;
+  border: 1px solid #29487d;
+  border-radius: 2px;
+  cursor: pointer;
+  font-size: 10px;
+  font-family: inherit;
+}
+
+.mb-friend-btn:hover {
+  background: #5b83db;
+}
+
+/* Tabs */
+.mb-tabs {
+  display: flex;
+  background: #d8dfea;
+  border-bottom: 1px solid #3b5998;
+}
+
+.mb-tab {
+  padding: 6px 14px;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: #3b5998;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+}
+
+.mb-tab:hover {
+  background: #c8cfda;
+}
+
+.mb-tab.active {
+  background: #fff;
+  border-color: #3b5998;
+  font-weight: bold;
+}
+
+/* Content area */
+.mb-content {
+  flex: 1;
+  overflow-y: auto;
+}
+
+/* Wall */
+.mb-wall {
+  padding: 8px;
+}
+
+.mb-compose {
+  background: #fff;
+  border: 1px solid #dddfe2;
+  border-radius: 3px;
+  padding: 8px;
+  margin-bottom: 10px;
+}
+
+.mb-compose textarea {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px;
+  border: 1px solid #bdc7d8;
+  border-radius: 3px;
+  background: #f6f7f8;
+  font-family: inherit;
+  font-size: 12px;
+  resize: none;
+  height: 48px;
+  outline: none;
+}
+
+.mb-compose textarea:focus {
+  border-color: #3b5998;
+  background: #fff;
+}
+
+.mb-compose-actions {
+  text-align: right;
+  margin-top: 6px;
+}
+
+.mb-post-btn {
+  padding: 3px 12px;
+  background: #5b74a8;
+  color: #fff;
+  border: 1px solid #29447e;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+}
+
+.mb-post-btn:hover {
+  background: #6d8bc4;
+}
+
+.mb-post-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+/* Posts */
+.mb-post {
+  display: flex;
+  gap: 8px;
+  background: #fff;
+  border: 1px solid #dddfe2;
+  border-radius: 3px;
+  padding: 8px;
+  margin-bottom: 6px;
+}
+
+.mb-post-avatar {
+  width: 32px;
+  height: 32px;
+  background: #8b9dc3;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: bold;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.mb-post-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.mb-post-author {
+  color: #3b5998;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.mb-post-author:hover {
+  text-decoration: underline;
+}
+
+.mb-post-content {
+  margin-top: 4px;
+  line-height: 1.4;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.mb-post-meta {
+  margin-top: 4px;
+  font-size: 10px;
+  color: #90949c;
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+
+.mb-delete-btn {
+  background: none;
+  border: none;
+  color: #cd201f;
+  cursor: pointer;
+  font-size: 10px;
+  font-family: inherit;
+}
+
+.mb-delete-btn:hover {
+  text-decoration: underline;
+}
+
+.mb-load-more {
+  text-align: center;
+  padding: 8px;
+}
+
+.mb-load-more button {
+  padding: 4px 12px;
+  background: #5b74a8;
+  color: #fff;
+  border: 1px solid #29447e;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+}
+
+/* Info tab */
+.mb-info {
+  padding: 12px;
+}
+
+.mb-info-field {
+  margin-bottom: 12px;
+}
+
+.mb-info-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #90949c;
+  margin-bottom: 2px;
+}
+
+.mb-info-value {
+  line-height: 1.4;
+}
+
+.mb-info-value a {
+  color: #3b5998;
+  text-decoration: none;
+}
+
+.mb-info-value a:hover {
+  text-decoration: underline;
+}
+
+/* Friends tab */
+.mb-friends {
+  padding: 8px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(110px, 1fr));
+  gap: 8px;
+}
+
+.mb-friend-card {
+  background: #fff;
+  border: 1px solid #dddfe2;
+  border-radius: 3px;
+  padding: 10px;
+  text-align: center;
+  cursor: pointer;
+}
+
+.mb-friend-card:hover {
+  background: #f0f2ff;
+}
+
+.mb-friend-avatar {
+  width: 40px;
+  height: 40px;
+  background: #8b9dc3;
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  font-weight: bold;
+  color: #fff;
+  margin: 0 auto 6px;
+}
+
+.mb-friend-name {
+  font-size: 11px;
+  font-weight: bold;
+  color: #3b5998;
+}
+
+.mb-friend-status {
+  font-size: 10px;
+  margin-top: 2px;
+}
+
+.mb-friend-status.online {
+  color: #0a0;
+}
+
+.mb-friend-status.offline {
+  color: #999;
+}
+
+.mb-empty {
+  text-align: center;
+  color: #90949c;
+  font-style: italic;
+  padding: 30px;
+}
+
+/* ── MutantMessenger (ICQ 90s style) ────────────────────────────────────── */
+
+.mm-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #004080;
+  font-family: 'MS Sans Serif', Tahoma, Arial, sans-serif;
+  font-size: 11px;
+  color: #fff;
+}
+
+.mm-loading,
+.mm-error {
+  padding: 40px;
+  text-align: center;
+  color: #fff;
+}
+
+.mm-error {
+  color: #ff6666;
+}
+
+/* Buddy List */
+.mm-buddy-list {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.mm-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  background: linear-gradient(180deg, #0066cc 0%, #004080 100%);
+  border-bottom: 1px solid #003366;
+}
+
+.mm-flower {
+  font-size: 20px;
+  animation: mm-flower-spin 3s linear infinite;
+}
+
+@keyframes mm-flower-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}
+
+.mm-title {
+  font-size: 13px;
+  font-weight: bold;
+  text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.5);
+}
+
+.mm-unread-badge {
+  background: #ff3333;
+  color: #fff;
+  font-size: 10px;
+  font-weight: bold;
+  padding: 2px 6px;
+  border-radius: 10px;
+  margin-left: auto;
+}
+
+.mm-status-bar {
+  padding: 4px 8px;
+  background: #003366;
+  font-size: 10px;
+  color: #99ccff;
+}
+
+.mm-contacts {
+  flex: 1;
+  overflow-y: auto;
+  background: #002244;
+}
+
+.mm-contact {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  cursor: pointer;
+}
+
+.mm-contact:hover {
+  background: #003366;
+}
+
+.mm-contact.unread {
+  background: #004080;
+}
+
+.mm-contact-avatar {
+  width: 28px;
+  height: 28px;
+  background: #6699cc;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  font-weight: bold;
+  color: #fff;
+}
+
+.mm-contact-info {
+  flex: 1;
+  min-width: 0;
+}
+
+.mm-contact-name {
+  font-weight: bold;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.mm-contact-status {
+  font-size: 10px;
+  color: #99ccff;
+}
+
+.mm-contact-status.online {
+  color: #66ff66;
+}
+
+.mm-contact.unread .mm-contact-name {
+  color: #ffff66;
+}
+
+.mm-contact-unread {
+  background: #ff3333;
+  color: #fff;
+  font-size: 9px;
+  font-weight: bold;
+  padding: 2px 5px;
+  border-radius: 8px;
+  min-width: 16px;
+  text-align: center;
+}
+
+.mm-separator {
+  padding: 4px 8px;
+  font-size: 10px;
+  color: #6699cc;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  background: #001833;
+}
+
+.mm-empty {
+  padding: 30px;
+  text-align: center;
+  color: #6699cc;
+  font-style: italic;
+}
+
+/* Chat View */
+.mm-chat {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background: #fff;
+}
+
+.mm-chat-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px;
+  background: linear-gradient(180deg, #0066cc 0%, #004080 100%);
+  color: #fff;
+}
+
+.mm-back-btn {
+  background: #003366;
+  border: 1px solid #002244;
+  color: #fff;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+}
+
+.mm-back-btn:hover {
+  background: #004080;
+}
+
+.mm-chat-avatar {
+  width: 32px;
+  height: 32px;
+  background: #6699cc;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+  font-weight: bold;
+  color: #fff;
+}
+
+.mm-chat-info {
+  flex: 1;
+}
+
+.mm-chat-name {
+  font-weight: bold;
+}
+
+.mm-chat-status {
+  font-size: 10px;
+  color: #99ccff;
+}
+
+.mm-chat-status.online {
+  color: #66ff66;
+}
+
+.mm-messages {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+  background: #f0f0f0;
+}
+
+.mm-messages-empty {
+  padding: 40px;
+  text-align: center;
+  color: #666;
+  font-style: italic;
+}
+
+.mm-message {
+  margin-bottom: 8px;
+  max-width: 80%;
+}
+
+.mm-message.outgoing {
+  margin-left: auto;
+}
+
+.mm-message-content {
+  padding: 6px 10px;
+  border-radius: 8px;
+  word-wrap: break-word;
+}
+
+.mm-message.incoming .mm-message-content {
+  background: #fff;
+  color: #000;
+  border: 1px solid #ddd;
+}
+
+.mm-message.outgoing .mm-message-content {
+  background: #0066cc;
+  color: #fff;
+}
+
+.mm-message-time {
+  font-size: 9px;
+  color: #999;
+  margin-top: 2px;
+}
+
+.mm-message.outgoing .mm-message-time {
+  text-align: right;
+}
+
+.mm-typing {
+  padding: 4px 8px;
+  font-size: 10px;
+  color: #666;
+  font-style: italic;
+  background: #f0f0f0;
+}
+
+.mm-compose {
+  display: flex;
+  gap: 4px;
+  padding: 8px;
+  background: #e0e0e0;
+  border-top: 1px solid #ccc;
+}
+
+.mm-compose textarea {
+  flex: 1;
+  padding: 6px;
+  border: 1px solid #999;
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 11px;
+  resize: none;
+  height: 40px;
+  outline: none;
+}
+
+.mm-compose textarea:focus {
+  border-color: #0066cc;
+}
+
+.mm-send-btn {
+  padding: 6px 12px;
+  background: #0066cc;
+  color: #fff;
+  border: 1px solid #004080;
+  border-radius: 3px;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+}
+
+.mm-send-btn:hover {
+  background: #0080ff;
+}
+
+.mm-send-btn:disabled {
+  background: #999;
+  cursor: default;
+}
+
+/* ── MutantMail (Yahoo Mail 1997-2000 style) ─────────────────────────────── */
+
+.ml-root {
+  display: flex;
+  height: 100%;
+  background: #f0e6d2;
+  font-family: Arial, Helvetica, sans-serif;
+  font-size: 12px;
+  color: #333;
+}
+
+/* Sidebar */
+.ml-sidebar {
+  width: 150px;
+  background: #c9b896;
+  border-right: 2px solid #8b7355;
+  display: flex;
+  flex-direction: column;
+}
+
+.ml-logo {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 10px;
+  background: #8b4513;
+  color: #fff;
+  font-weight: bold;
+}
+
+.ml-logo-icon {
+  font-size: 18px;
+}
+
+.ml-logo-text {
+  font-size: 14px;
+}
+
+.ml-compose-btn {
+  margin: 10px;
+  padding: 8px 12px;
+  background: #d4a574;
+  border: 2px outset #e8c9a0;
+  color: #333;
+  cursor: pointer;
+  font-size: 12px;
+  font-weight: bold;
+  font-family: inherit;
+}
+
+.ml-compose-btn:hover {
+  background: #e8c9a0;
+}
+
+.ml-compose-btn:active {
+  border-style: inset;
+}
+
+.ml-folders {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.ml-folder {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  cursor: pointer;
+  border-bottom: 1px solid #b8a078;
+}
+
+.ml-folder:hover {
+  background: #d4c4a0;
+}
+
+.ml-folder.active {
+  background: #f0e6d2;
+  font-weight: bold;
+}
+
+.ml-folder-icon {
+  font-size: 14px;
+}
+
+.ml-folder-label {
+  flex: 1;
+}
+
+.ml-folder-count {
+  background: #8b4513;
+  color: #fff;
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 8px;
+}
+
+/* Main content */
+.ml-main {
+  flex: 1;
+  display: flex;
+  overflow: hidden;
+}
+
+/* Message list */
+.ml-list {
+  width: 280px;
+  display: flex;
+  flex-direction: column;
+  border-right: 2px solid #c9b896;
+  background: #fff;
+}
+
+.ml-list-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px;
+  background: #d4c4a0;
+  border-bottom: 1px solid #c9b896;
+  font-weight: bold;
+}
+
+.ml-list-title {
+  font-size: 13px;
+}
+
+.ml-list-count {
+  font-size: 10px;
+  color: #8b4513;
+}
+
+.ml-messages {
+  flex: 1;
+  overflow-y: auto;
+}
+
+.ml-message-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  border-bottom: 1px solid #e0d8c8;
+  cursor: pointer;
+}
+
+.ml-message-row:hover {
+  background: #f5f0e8;
+}
+
+.ml-message-row.unread {
+  background: #fffef0;
+  font-weight: bold;
+}
+
+.ml-message-row.selected {
+  background: #d4c4a0;
+}
+
+.ml-message-checkbox {
+  width: 16px;
+}
+
+.ml-message-checkbox input {
+  margin: 0;
+}
+
+.ml-message-from {
+  width: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.ml-unread-dot {
+  color: #8b4513;
+  font-size: 8px;
+}
+
+.ml-message-subject {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ml-message-date {
+  width: 60px;
+  font-size: 10px;
+  color: #666;
+  text-align: right;
+}
+
+.ml-empty {
+  padding: 30px;
+  text-align: center;
+  color: #8b7355;
+  font-style: italic;
+}
+
+/* Preview pane */
+.ml-preview {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  background: #fff;
+}
+
+.ml-no-selection {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #8b7355;
+  font-style: italic;
+}
+
+/* Message view */
+.ml-message-view {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.ml-view-header {
+  padding: 12px;
+  background: #f5f0e8;
+  border-bottom: 1px solid #d4c4a0;
+}
+
+.ml-view-subject {
+  font-size: 14px;
+  font-weight: bold;
+  margin-bottom: 8px;
+}
+
+.ml-view-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 11px;
+  color: #666;
+}
+
+.ml-view-from,
+.ml-view-to {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ml-view-date {
+  margin-left: auto;
+}
+
+.ml-view-body {
+  flex: 1;
+  padding: 12px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  line-height: 1.5;
+}
+
+.ml-view-actions {
+  display: flex;
+  gap: 8px;
+  padding: 8px 12px;
+  background: #f5f0e8;
+  border-top: 1px solid #d4c4a0;
+}
+
+.ml-action-btn {
+  padding: 6px 12px;
+  background: #d4a574;
+  border: 2px outset #e8c9a0;
+  color: #333;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+}
+
+.ml-action-btn:hover {
+  background: #e8c9a0;
+}
+
+.ml-action-btn:active {
+  border-style: inset;
+}
+
+.ml-action-btn.delete {
+  background: #c9b896;
+}
+
+.ml-action-btn.delete:hover {
+  background: #b8a078;
+}
+
+/* Compose form */
+.ml-compose-form {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.ml-compose-header {
+  padding: 10px 12px;
+  background: #d4c4a0;
+  border-bottom: 1px solid #c9b896;
+  font-weight: bold;
+  font-size: 13px;
+}
+
+.ml-compose-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-bottom: 1px solid #e0d8c8;
+}
+
+.ml-compose-field label {
+  width: 60px;
+  font-weight: bold;
+  color: #666;
+}
+
+.ml-compose-field input {
+  flex: 1;
+  padding: 4px 6px;
+  border: 1px solid #c9b896;
+  background: #fff;
+  font-family: inherit;
+  font-size: 12px;
+  outline: none;
+}
+
+.ml-compose-field input:focus {
+  border-color: #8b4513;
+}
+
+.ml-compose-body {
+  flex: 1;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+}
+
+.ml-compose-body textarea {
+  flex: 1;
+  padding: 8px;
+  border: 1px solid #c9b896;
+  background: #fff;
+  font-family: inherit;
+  font-size: 12px;
+  resize: none;
+  outline: none;
+  line-height: 1.5;
+}
+
+.ml-compose-body textarea:focus {
+  border-color: #8b4513;
+}
+
+.ml-compose-actions {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+  padding: 8px 12px;
+  background: #f5f0e8;
+  border-top: 1px solid #d4c4a0;
+}
+
+.ml-send-btn {
+  padding: 6px 16px;
+  background: #8b4513;
+  border: 2px outset #a0522d;
+  color: #fff;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: bold;
+  font-family: inherit;
+}
+
+.ml-send-btn:hover {
+  background: #a0522d;
+}
+
+.ml-send-btn:active {
+  border-style: inset;
+}
+
+.ml-send-btn:disabled {
+  background: #999;
+  border-color: #aaa;
+  cursor: default;
+}
+
+.ml-cancel-btn {
+  padding: 6px 12px;
+  background: #c9b896;
+  border: 2px outset #d4c4a0;
+  color: #333;
+  cursor: pointer;
+  font-size: 11px;
+  font-family: inherit;
+}
+
+.ml-cancel-btn:hover {
+  background: #d4c4a0;
+}
+
+.ml-cancel-btn:active {
+  border-style: inset;
 }

--- a/packages/konpyuuta/src/styles/cde.css
+++ b/packages/konpyuuta/src/styles/cde.css
@@ -3095,3 +3095,1221 @@
     padding: 6px;
   }
 }
+
+/* ═════════════════════════════════════════════════════════════════════════════
+   MUTANT::TUBE - BIO-INDUSTRIAL ARCHIVE
+   Aesthetic: Geiger meets Winamp in a corrupted server farm
+   Scoped under .mt-root for isolation
+   ═════════════════════════════════════════════════════════════════════════════ */
+
+.mt-root {
+  --void-black: #0a0a0a;
+  --rust-orange: #B7410E;
+  --rust-dark: #8B4513;
+  --slime-green: #9ACD32;
+  --slime-dark: #556B2F;
+  --bone: #F5F5DC;
+  --bone-dim: #C0C0C0;
+  --steel: #2F4F4F;
+  --steel-light: #4A6464;
+  --warning: #FFBF00;
+  --blood: #8B0000;
+  --panel-bg: #1a1a1a;
+
+  font-family: 'Chakra Petch', sans-serif;
+  font-size: 13px;
+  background: var(--void-black);
+  color: var(--bone);
+  min-height: 100%;
+  overflow-x: hidden;
+  box-sizing: border-box;
+}
+
+.mt-root *, .mt-root *::before, .mt-root *::after { box-sizing: border-box; }
+
+/* Organic pulsing background pattern */
+.mt-root::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  background: 
+    radial-gradient(ellipse at 20% 80%, rgba(183, 65, 14, 0.1) 0%, transparent 50%),
+    radial-gradient(ellipse at 80% 20%, rgba(154, 205, 50, 0.05) 0%, transparent 50%),
+    repeating-linear-gradient(90deg, rgba(139, 69, 19, 0.03) 0px, rgba(139, 69, 19, 0.03) 1px, transparent 1px, transparent 60px);
+  pointer-events: none;
+  z-index: -1;
+  animation: organic-breathe 12s ease-in-out infinite;
+}
+
+@keyframes organic-breathe {
+  0%, 100% { opacity: 0.8; transform: scale(1); }
+  50% { opacity: 1; transform: scale(1.01); }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   LOADING ANIMATION
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root .loading-container {
+  text-align: center;
+  padding: 60px 40px;
+  background: var(--panel-bg);
+  border: 2px solid var(--rust-orange);
+  box-shadow: 
+    0 0 40px rgba(183, 65, 14, 0.2),
+    inset 0 0 60px rgba(0,0,0,0.5);
+  position: relative;
+  margin: 20px 0;
+}
+
+.mt-root .loading-container::before,
+.mt-root .loading-container::after {
+  content: '◉';
+  position: absolute;
+  color: var(--steel);
+  font-size: 12px;
+}
+
+.mt-root .loading-container::before { top: 8px; left: 8px; }
+.mt-root .loading-container::after { bottom: 8px; right: 8px; }
+
+.mt-root .loading-skull {
+  font-size: 48px;
+  margin-bottom: 16px;
+  animation: skull-pulse 1.2s ease-in-out infinite;
+  text-shadow: 0 0 20px rgba(183, 65, 14, 0.6);
+}
+
+@keyframes skull-pulse {
+  0%, 100% { transform: scale(1); filter: brightness(1); }
+  50% { transform: scale(1.08); filter: brightness(1.3); }
+}
+
+.mt-root .loading-text {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 14px;
+  color: var(--slime-green);
+  text-transform: uppercase;
+  letter-spacing: 3px;
+  margin-bottom: 20px;
+}
+
+.mt-root .loading-status {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 11px;
+  color: var(--bone-dim);
+  letter-spacing: 2px;
+  min-height: 20px;
+  animation: status-flicker 0.5s infinite;
+}
+
+@keyframes status-flicker {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+.mt-root .loading-progress {
+  width: 250px;
+  height: 3px;
+  background: var(--steel);
+  margin: 16px auto;
+  position: relative;
+  overflow: hidden;
+}
+
+.mt-root .loading-progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, var(--slime-green), var(--rust-orange));
+  width: 0%;
+  animation: progress-fill 1.5s ease-out forwards;
+  box-shadow: 0 0 8px var(--slime-green);
+}
+
+@keyframes progress-fill {
+  0% { width: 0%; }
+  100% { width: 100%; }
+}
+
+/* Matrix rain effect */
+.mt-root .matrix-rain {
+  position: absolute;
+  inset: 0;
+  overflow: hidden;
+  opacity: 0.08;
+  pointer-events: none;
+}
+
+.mt-root .matrix-char {
+  position: absolute;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 12px;
+  color: var(--slime-green);
+  animation: matrix-fall linear infinite;
+}
+
+@keyframes matrix-fall {
+  0% { transform: translateY(-100%); opacity: 0; }
+  10% { opacity: 1; }
+  90% { opacity: 1; }
+  100% { transform: translateY(100%); opacity: 0; }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   HEADER - Industrial Control Panel
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root #mt-header { 
+  background: linear-gradient(180deg, #2a2a2a 0%, var(--panel-bg) 100%);
+  border-bottom: 3px solid var(--rust-orange);
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  box-shadow: 
+    0 4px 20px rgba(183, 65, 14, 0.3),
+    inset 0 1px 0 rgba(255,255,255,0.1);
+  position: relative;
+}
+
+.mt-root #mt-header::before,
+.mt-root #mt-header::after {
+  content: '◉';
+  position: absolute;
+  color: var(--steel);
+  font-size: 10px;
+  top: 4px;
+}
+
+.mt-root #mt-header::before { left: 8px; }
+.mt-root #mt-header::after { right: 8px; }
+
+.mt-root .logo { 
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 24px; 
+  font-weight: 700;
+  letter-spacing: 2px;
+  color: var(--bone);
+  text-shadow: 
+    0 0 10px rgba(183, 65, 14, 0.5),
+    2px 2px 0 var(--blood);
+  position: relative;
+  animation: logo-flicker 8s infinite;
+}
+
+.mt-root .logo::after {
+  content: '::ARCHIVE';
+  color: var(--rust-orange);
+  font-size: 12px;
+  position: absolute;
+  bottom: -4px;
+  right: 0;
+  letter-spacing: 1px;
+}
+
+@keyframes logo-flicker {
+  0%, 90%, 100% { opacity: 1; }
+  91% { opacity: 0.8; }
+  92% { opacity: 1; }
+  93% { opacity: 0.7; }
+  94% { opacity: 1; }
+}
+
+.mt-root .header-status {
+  display: flex;
+  gap: 20px;
+  margin-left: auto;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 11px;
+  color: var(--slime-green);
+}
+
+.mt-root .status-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.mt-root .status-indicator {
+  width: 8px;
+  height: 8px;
+  background: var(--slime-green);
+  border-radius: 50%;
+  animation: status-pulse 2s infinite;
+  box-shadow: 0 0 8px var(--slime-green);
+}
+
+@keyframes status-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.mt-root #mt-search-form { 
+  display: flex; 
+  gap: 8px; 
+  flex: 1; 
+  max-width: 400px;
+  position: relative;
+}
+
+.mt-root #mt-search-form::before {
+  content: '>';
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--rust-orange);
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 14px;
+  z-index: 1;
+}
+
+.mt-root #mt-search-input { 
+  flex: 1; 
+  padding: 8px 12px 8px 28px;
+  background: #0f0f0f;
+  border: 1px solid var(--steel);
+  color: var(--bone);
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 13px;
+  outline: none;
+  transition: all 0.3s;
+}
+
+.mt-root #mt-search-input:focus {
+  border-color: var(--rust-orange);
+  box-shadow: 
+    0 0 10px rgba(183, 65, 14, 0.3),
+    inset 0 0 20px rgba(183, 65, 14, 0.05);
+}
+
+.mt-root #mt-search-btn { 
+  padding: 8px 18px;
+  background: linear-gradient(180deg, var(--rust-dark) 0%, var(--rust-orange) 100%);
+  border: 1px solid var(--rust-orange);
+  color: var(--bone);
+  cursor: pointer;
+  font-family: 'Chakra Petch', sans-serif;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  transition: all 0.2s;
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mt-root #mt-search-btn:hover { 
+  background: linear-gradient(180deg, var(--rust-orange) 0%, var(--rust-dark) 100%);
+  box-shadow: 0 0 15px rgba(183, 65, 14, 0.5);
+}
+
+.mt-root #mt-search-btn::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 100%;
+  height: 100%;
+  background: linear-gradient(90deg, transparent, rgba(255,255,255,0.2), transparent);
+  transition: left 0.5s;
+}
+
+.mt-root #mt-search-btn:hover::before {
+  left: 100%;
+}
+
+.mt-root .btn-skull {
+  font-size: 14px;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   NAVIGATION TABS
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root #mt-tabs { 
+  background: var(--panel-bg);
+  border-bottom: 2px solid var(--steel);
+  padding: 0 16px;
+  display: flex;
+  gap: 4px;
+}
+
+.mt-root .mt-tab { 
+  padding: 10px 20px;
+  cursor: pointer;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  background: transparent;
+  border: none;
+  border-bottom: 3px solid transparent;
+  color: var(--bone-dim);
+  position: relative;
+  transition: all 0.3s;
+}
+
+.mt-root .mt-tab:hover { 
+  color: var(--bone);
+  background: rgba(183, 65, 14, 0.1);
+}
+
+.mt-root .mt-tab.active { 
+  color: var(--rust-orange);
+  border-bottom-color: var(--rust-orange);
+  background: linear-gradient(180deg, transparent 0%, rgba(183, 65, 14, 0.1) 100%);
+  text-shadow: 0 0 10px rgba(183, 65, 14, 0.5);
+}
+
+.mt-root .mt-tab.active::before {
+  content: '◆';
+  position: absolute;
+  left: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 8px;
+  animation: tab-pulse 2s infinite;
+}
+
+@keyframes tab-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   MAIN LAYOUT
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root #mt-main { 
+  display: flex;
+  min-height: calc(100% - 130px);
+  padding-bottom: 60px;
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   SIDEBAR - System Directories
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root #mt-sidebar { 
+  width: 200px;
+  background: linear-gradient(180deg, var(--panel-bg) 0%, #141414 100%);
+  padding: 16px;
+  border-right: 2px solid var(--steel);
+  flex-shrink: 0;
+  transition: all 0.3s;
+}
+
+.mt-root #mt-sidebar.hidden {
+  width: 0;
+  padding: 0;
+  border: none;
+  overflow: hidden;
+  opacity: 0;
+}
+
+.mt-root #mt-sidebar h3 { 
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  color: var(--slime-green);
+  margin-bottom: 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--steel);
+}
+
+.mt-root .directory-item {
+  padding: 8px 10px;
+  margin-bottom: 4px;
+  cursor: pointer;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 11px;
+  color: var(--bone-dim);
+  border-left: 2px solid transparent;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mt-root .directory-item::before {
+  content: '[ ]';
+  color: var(--steel);
+}
+
+.mt-root .directory-item:hover {
+  color: var(--bone);
+  background: rgba(139, 69, 19, 0.2);
+  border-left-color: var(--rust-orange);
+}
+
+.mt-root .directory-item:hover::before {
+  content: '[■]';
+  color: var(--rust-orange);
+}
+
+.mt-root .directory-item.active {
+  color: var(--slime-green);
+  border-left-color: var(--slime-green);
+  background: rgba(154, 205, 50, 0.1);
+}
+
+.mt-root .directory-item.active::before {
+  content: '[■]';
+  color: var(--slime-green);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   CONTENT AREA
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root #mt-content { 
+  flex: 1;
+  padding: 20px;
+  background: rgba(10, 10, 10, 0.5);
+  overflow-y: auto;
+}
+
+.mt-root .section-title {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 14px;
+  color: var(--slime-green);
+  text-transform: uppercase;
+  letter-spacing: 3px;
+  margin-bottom: 20px;
+  padding: 10px 16px;
+  background: linear-gradient(90deg, rgba(154, 205, 50, 0.1) 0%, transparent 100%);
+  border-left: 4px solid var(--slime-green);
+  position: relative;
+}
+
+.mt-root .section-title::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: linear-gradient(90deg, var(--slime-green), transparent);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   VIDEO GRID - Masonry with Corruption Effects
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root .mt-masonry {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.mt-root .mt-video-card { 
+  cursor: pointer;
+  background: var(--panel-bg);
+  border: 1px solid var(--steel);
+  transition: all 0.3s;
+  position: relative;
+  overflow: hidden;
+}
+
+.mt-root .mt-video-card::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border: 1px solid transparent;
+  transition: border-color 0.3s;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.mt-root .mt-video-card:hover {
+  transform: translateY(-4px);
+  border-color: var(--rust-orange);
+  box-shadow: 
+    0 10px 40px rgba(0,0,0,0.5),
+    0 0 20px rgba(183, 65, 14, 0.2);
+}
+
+.mt-root .mt-video-card:hover::before {
+  border-color: var(--rust-orange);
+}
+
+.mt-root .mt-thumb-container {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16/9;
+  overflow: hidden;
+  background: #000;
+}
+
+.mt-root .mt-thumb { 
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  transition: all 0.4s;
+  filter: contrast(1.1) saturate(0.9);
+}
+
+.mt-root .mt-thumb-container::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0,0,0,0.1) 2px,
+    rgba(0,0,0,0.1) 4px
+  );
+  pointer-events: none;
+  animation: scanline-shift 10s linear infinite;
+  opacity: 0.6;
+}
+
+@keyframes scanline-shift {
+  0% { background-position: 0 0; }
+  100% { background-position: 0 100px; }
+}
+
+.mt-root .mt-video-card:hover .mt-thumb {
+  filter: contrast(1.2) saturate(1.1);
+  animation: chromatic-shift 0.3s ease-out;
+}
+
+@keyframes chromatic-shift {
+  0% { 
+    filter: contrast(1.2) saturate(1.1) drop-shadow(-2px 0 0 rgba(255,0,0,0.3)) drop-shadow(2px 0 0 rgba(0,255,255,0.3));
+  }
+  100% { 
+    filter: contrast(1.2) saturate(1.1);
+  }
+}
+
+.mt-root .mt-thumb-container::before {
+  content: '▶';
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 48px;
+  color: var(--bone);
+  background: rgba(0,0,0,0.4);
+  opacity: 0;
+  transition: all 0.3s;
+  z-index: 1;
+  text-shadow: 0 0 20px rgba(0,0,0,0.8);
+}
+
+.mt-root .mt-video-card:hover .mt-thumb-container::before {
+  opacity: 1;
+}
+
+.mt-root .mt-thumb-placeholder { 
+  width: 100%;
+  aspect-ratio: 16/9;
+  background: 
+    repeating-linear-gradient(45deg, #1a1a1a 0px, #1a1a1a 10px, #222 10px, #222 20px),
+    linear-gradient(180deg, var(--rust-dark) 0%, var(--blood) 100%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--bone);
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 32px;
+}
+
+.mt-root .mt-video-info {
+  padding: 12px;
+}
+
+.mt-root .mt-video-title { 
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--bone);
+  line-height: 1.4;
+  margin-bottom: 6px;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  transition: color 0.2s;
+}
+
+.mt-root .mt-video-card:hover .mt-video-title {
+  color: var(--rust-orange);
+}
+
+.mt-root .mt-video-title.glitch {
+  animation: text-glitch 0.3s ease-out;
+}
+
+@keyframes text-glitch {
+  0%, 100% { transform: translate(0); }
+  20% { transform: translate(-2px, 1px); }
+  40% { transform: translate(2px, -1px); }
+  60% { transform: translate(-1px, 2px); }
+  80% { transform: translate(1px, -2px); }
+}
+
+.mt-root .mt-video-meta { 
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 10px;
+  color: var(--steel);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.mt-root .mt-video-meta span {
+  color: var(--slime-green);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   WATCH VIEW - EPIC & WEIRD
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root #mt-watch { 
+  max-width: 1200px;
+  margin: 0 auto;
+  position: relative;
+}
+
+.mt-root .back-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px;
+  margin-bottom: 20px;
+  background: transparent;
+  border: 1px solid var(--steel);
+  color: var(--bone-dim);
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.mt-root .back-btn:hover {
+  border-color: var(--rust-orange);
+  color: var(--rust-orange);
+  background: rgba(183, 65, 14, 0.1);
+}
+
+.mt-root #mt-watch-frame-container {
+  position: relative;
+  background: #000;
+  border: 3px solid var(--rust-orange);
+  box-shadow: 
+    0 0 60px rgba(183, 65, 14, 0.3),
+    inset 0 0 100px rgba(0,0,0,0.5);
+  padding: 20px;
+}
+
+/* Corner decorations */
+.mt-root .corner-decoration {
+  position: absolute;
+  width: 40px;
+  height: 40px;
+  border: 2px solid var(--slime-green);
+  z-index: 10;
+}
+
+.mt-root .corner-tl { top: -3px; left: -3px; border-right: none; border-bottom: none; }
+.mt-root .corner-tr { top: -3px; right: -3px; border-left: none; border-bottom: none; }
+.mt-root .corner-bl { bottom: -3px; left: -3px; border-right: none; border-top: none; }
+.mt-root .corner-br { bottom: -3px; right: -3px; border-left: none; border-top: none; }
+
+.mt-root .corner-decoration::before {
+  content: '◉';
+  position: absolute;
+  font-size: 8px;
+  color: var(--rust-orange);
+}
+
+.mt-root .corner-tl::before { top: 2px; left: 2px; }
+.mt-root .corner-tr::before { top: 2px; right: 2px; }
+.mt-root .corner-bl::before { bottom: 2px; left: 2px; }
+.mt-root .corner-br::before { bottom: 2px; right: 2px; }
+
+/* Scanlines overlay on video */
+.mt-root .video-scanlines {
+  position: absolute;
+  inset: 20px;
+  pointer-events: none;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0,0,0,0.15) 2px,
+    rgba(0,0,0,0.15) 4px
+  );
+  z-index: 5;
+  opacity: 0.6;
+}
+
+/* Warning labels */
+.mt-root .video-warning {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: var(--blood);
+  color: var(--bone);
+  padding: 4px 12px;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  z-index: 10;
+  animation: warning-blink 1s infinite;
+}
+
+@keyframes warning-blink {
+  0%, 50% { opacity: 1; }
+  51%, 100% { opacity: 0.5; }
+}
+
+.mt-root #mt-watch-frame { 
+  width: 100%;
+  aspect-ratio: 16/9;
+  border: none;
+  background: #000;
+  display: block;
+}
+
+/* Video info panel */
+.mt-root #mt-watch-info {
+  margin-top: 20px;
+  padding: 24px;
+  background: var(--panel-bg);
+  border: 2px solid var(--steel);
+  position: relative;
+}
+
+.mt-root #mt-watch-info::before {
+  content: '◈ SIGNAL ACQUIRED ◈';
+  position: absolute;
+  top: -10px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--void-black);
+  padding: 0 20px;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 11px;
+  color: var(--slime-green);
+  letter-spacing: 3px;
+}
+
+.mt-root #mt-watch-title { 
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--bone);
+  margin-bottom: 16px;
+  font-family: 'Share Tech Mono', monospace;
+  text-shadow: 0 0 10px rgba(183, 65, 14, 0.3);
+}
+
+/* Weird stats */
+.mt-root .video-stats {
+  display: flex;
+  gap: 24px;
+  margin-bottom: 20px;
+  padding: 16px;
+  background: rgba(0,0,0,0.3);
+  border-left: 3px solid var(--rust-orange);
+}
+
+.mt-root .stat-item {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 11px;
+}
+
+.mt-root .stat-label {
+  color: var(--steel);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 4px;
+}
+
+.mt-root .stat-value {
+  color: var(--slime-green);
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.mt-root #mt-watch-actions { 
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.mt-root .action-btn {
+  padding: 12px 24px;
+  background: linear-gradient(180deg, var(--steel) 0%, var(--steel-light) 100%);
+  border: 2px solid var(--steel);
+  color: var(--bone);
+  font-family: 'Chakra Petch', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mt-root .action-btn:hover {
+  background: linear-gradient(180deg, var(--rust-dark) 0%, var(--rust-orange) 100%);
+  border-color: var(--rust-orange);
+  box-shadow: 0 0 20px rgba(183, 65, 14, 0.4);
+  transform: translateY(-2px);
+}
+
+.mt-root .action-btn.primary {
+  background: linear-gradient(180deg, var(--slime-dark) 0%, var(--slime-green) 100%);
+  border-color: var(--slime-green);
+  color: var(--void-black);
+}
+
+.mt-root .action-btn.primary:hover {
+  box-shadow: 0 0 20px rgba(154, 205, 50, 0.4);
+}
+
+/* Glitchy decorations */
+.mt-root .glitch-decoration {
+  position: absolute;
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 10px;
+  color: var(--blood);
+  opacity: 0.3;
+  pointer-events: none;
+  animation: glitch-float 3s ease-in-out infinite;
+}
+
+@keyframes glitch-float {
+  0%, 100% { transform: translate(0, 0) rotate(0deg); }
+  25% { transform: translate(5px, -5px) rotate(2deg); }
+  50% { transform: translate(-3px, 3px) rotate(-1deg); }
+  75% { transform: translate(4px, 2px) rotate(1deg); }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   PLAYLIST STYLES
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root .mt-playlist-item { 
+  padding: 14px 16px;
+  margin-bottom: 8px;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  background: var(--panel-bg);
+  border: 1px solid var(--steel);
+  border-left: 3px solid var(--steel);
+  transition: all 0.3s;
+}
+
+.mt-root .mt-playlist-item:hover { 
+  background: rgba(139, 69, 19, 0.1);
+  border-color: var(--rust-orange);
+  border-left-color: var(--rust-orange);
+  transform: translateX(4px);
+}
+
+.mt-root .mt-playlist-info {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.mt-root .mt-playlist-name { 
+  font-weight: 600;
+  font-size: 14px;
+  color: var(--bone);
+  font-family: 'Share Tech Mono', monospace;
+}
+
+.mt-root .mt-playlist-count { 
+  font-size: 10px;
+  color: var(--slime-green);
+  font-family: 'Share Tech Mono', monospace;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.mt-root .mt-btn-delete { 
+  color: var(--blood);
+  font-size: 11px;
+  cursor: pointer;
+  background: transparent;
+  border: 1px solid var(--blood);
+  padding: 6px 12px;
+  font-family: 'Share Tech Mono', monospace;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  transition: all 0.2s;
+}
+
+.mt-root .mt-btn-delete:hover {
+  background: var(--blood);
+  color: var(--bone);
+}
+
+.mt-root .mt-btn-new { 
+  padding: 12px 24px;
+  background: linear-gradient(180deg, var(--slime-dark) 0%, var(--slime-green) 100%);
+  border: 1px solid var(--slime-green);
+  color: var(--void-black);
+  font-family: 'Chakra Petch', sans-serif;
+  font-weight: 700;
+  font-size: 13px;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  cursor: pointer;
+  margin-bottom: 20px;
+  transition: all 0.3s;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.mt-root .mt-btn-new:hover {
+  box-shadow: 0 0 20px rgba(154, 205, 50, 0.4);
+  transform: translateY(-2px);
+}
+
+.mt-root .mt-track-item { 
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--steel);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  cursor: pointer;
+  background: rgba(20, 20, 20, 0.5);
+  transition: all 0.2s;
+}
+
+.mt-root .mt-track-item:hover { 
+  background: rgba(183, 65, 14, 0.1);
+  border-left: 3px solid var(--rust-orange);
+  margin-left: -3px;
+  padding-left: 19px;
+}
+
+.mt-root .mt-track-title { 
+  font-size: 13px;
+  color: var(--bone-dim);
+  font-family: 'Share Tech Mono', monospace;
+}
+
+.mt-root .mt-track-item:hover .mt-track-title {
+  color: var(--bone);
+}
+
+.mt-root .mt-btn-back { 
+  padding: 8px 16px;
+  font-size: 12px;
+  cursor: pointer;
+  border: 1px solid var(--steel);
+  background: transparent;
+  color: var(--bone-dim);
+  font-family: 'Share Tech Mono', monospace;
+  text-transform: uppercase;
+  letter-spacing: 1px;
+  margin-bottom: 16px;
+  transition: all 0.2s;
+}
+
+.mt-root .mt-btn-back:hover { 
+  border-color: var(--rust-orange);
+  color: var(--rust-orange);
+  background: rgba(183, 65, 14, 0.1);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   PAGINATION
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root .pagination {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 8px;
+  margin-top: 32px;
+  padding: 20px;
+}
+
+.mt-root .pagination-btn {
+  padding: 10px 18px;
+  background: transparent;
+  border: 1px solid var(--steel);
+  color: var(--bone-dim);
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 12px;
+  cursor: pointer;
+  transition: all 0.2s;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.mt-root .pagination-btn:hover:not(:disabled) {
+  border-color: var(--rust-orange);
+  color: var(--rust-orange);
+  background: rgba(183, 65, 14, 0.1);
+}
+
+.mt-root .pagination-btn:disabled {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
+.mt-root .pagination-info {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 12px;
+  color: var(--slime-green);
+  padding: 0 16px;
+}
+
+.mt-root .pagination-info span {
+  color: var(--bone);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   STATUS BAR
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root #mt-status-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: var(--panel-bg);
+  border-top: 2px solid var(--steel);
+  padding: 8px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  z-index: 100;
+}
+
+.mt-root .status-text {
+  font-family: 'Share Tech Mono', monospace;
+  font-size: 11px;
+  color: var(--slime-green);
+  text-transform: uppercase;
+  letter-spacing: 1px;
+}
+
+.mt-root .equalizer {
+  display: flex;
+  align-items: end;
+  gap: 2px;
+  height: 24px;
+}
+
+.mt-root .eq-bar {
+  width: 4px;
+  background: linear-gradient(180deg, var(--slime-green) 0%, var(--rust-orange) 100%);
+  animation: eq-bounce 0.5s ease-in-out infinite alternate;
+}
+
+.mt-root .eq-bar:nth-child(1) { height: 40%; animation-delay: 0s; }
+.mt-root .eq-bar:nth-child(2) { height: 70%; animation-delay: 0.1s; }
+.mt-root .eq-bar:nth-child(3) { height: 50%; animation-delay: 0.2s; }
+.mt-root .eq-bar:nth-child(4) { height: 80%; animation-delay: 0.05s; }
+.mt-root .eq-bar:nth-child(5) { height: 60%; animation-delay: 0.15s; }
+.mt-root .eq-bar:nth-child(6) { height: 90%; animation-delay: 0.08s; }
+.mt-root .eq-bar:nth-child(7) { height: 45%; animation-delay: 0.12s; }
+.mt-root .eq-bar:nth-child(8) { height: 75%; animation-delay: 0.03s; }
+.mt-root .eq-bar:nth-child(9) { height: 55%; animation-delay: 0.18s; }
+.mt-root .eq-bar:nth-child(10) { height: 85%; animation-delay: 0.07s; }
+
+@keyframes eq-bounce {
+  0% { transform: scaleY(0.3); opacity: 0.6; }
+  100% { transform: scaleY(1); opacity: 1; }
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   STATUS MESSAGES
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root #mt-status { 
+  color: var(--bone-dim);
+  font-size: 14px;
+  padding: 40px;
+  text-align: center;
+  font-family: 'Share Tech Mono', monospace;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+}
+
+.mt-root #mt-status::before {
+  content: '⟳ ';
+  animation: loading-spin 1s linear infinite;
+  display: inline-block;
+}
+
+@keyframes loading-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.mt-root #mt-error { 
+  color: var(--blood);
+  font-size: 14px;
+  padding: 40px;
+  text-align: center;
+  font-family: 'Share Tech Mono', monospace;
+  text-transform: uppercase;
+  letter-spacing: 2px;
+  border: 1px solid var(--blood);
+  background: rgba(139, 0, 0, 0.1);
+}
+
+.mt-root #mt-error::before {
+  content: '⚠ ';
+}
+
+.mt-root .empty-state {
+  text-align: center;
+  padding: 60px 20px;
+  color: var(--steel);
+  font-family: 'Share Tech Mono', monospace;
+}
+
+.mt-root .empty-state::before {
+  content: '[ EMPTY ]';
+  display: block;
+  font-size: 24px;
+  margin-bottom: 16px;
+  color: var(--steel-light);
+}
+
+/* ═══════════════════════════════════════════════════════════════
+   SCROLLBAR
+   ═══════════════════════════════════════════════════════════════ */
+
+.mt-root ::-webkit-scrollbar {
+  width: 10px;
+}
+
+.mt-root ::-webkit-scrollbar-track {
+  background: var(--void-black);
+}
+
+.mt-root ::-webkit-scrollbar-thumb {
+  background: var(--steel);
+  border: 2px solid var(--void-black);
+}
+
+.mt-root ::-webkit-scrollbar-thumb:hover {
+  background: var(--rust-orange);
+}

--- a/packages/konpyuuta/src/types.ts
+++ b/packages/konpyuuta/src/types.ts
@@ -32,10 +32,62 @@ export interface NotificationItem {
   createdAt: number
 }
 
+// ── Service Interfaces for Social Apps ─────────────────────────────────────
+
+export interface PlaylistTrack {
+  id: string
+  title: string
+  link: string
+  duration: number
+  thumbnail?: string
+}
+
+export interface Playlist {
+  id: string
+  name: string
+  items: PlaylistTrack[]
+}
+
+export interface PlaylistService {
+  getPlaylists: () => Playlist[]
+  createPlaylist: (name: string) => void
+  removePlaylist: (id: string) => void
+  addTrack: (playlistId: string, track: PlaylistTrack) => void
+  removeTrack: (playlistId: string, trackId: string) => void
+  loadFromServer: () => Promise<void>
+}
+
+export interface WallPost {
+  postId: string
+  authorId: string
+  authorUsername: string
+  targetUserId: string
+  content: string
+  createdAt: number
+}
+
+export interface UserProfile {
+  user_id: string
+  username: string
+  display_name: string
+  avatar_url: string
+  metadata: Record<string, unknown>
+}
+
+export interface SocialService {
+  getCurrentUserId: () => string | null
+  getCurrentUsername: () => string | null
+  getUserProfile: (userId: string) => Promise<UserProfile>
+  getMyAccount: () => Promise<UserProfile>
+  getWallPosts: (targetUserId: string, cursor?: string) => Promise<{ posts: WallPost[]; cursor?: string }>
+  createWallPost: (targetUserId: string, content: string) => Promise<WallPost>
+  deleteWallPost: (postId: string, targetUserId: string) => Promise<void>
+  listFriends: () => Promise<Array<{ userId: string; username: string; displayName: string; online: boolean }>>
+}
+
 export interface KonpyuuTAContextValue {
-  nakamaClient?: unknown
-  colyseusRoom?: unknown
-  authStore?: unknown
+  playlistService?: PlaylistService
+  socialService?: SocialService
   env: {
     youtubeApiUrl?: string
   }

--- a/packages/konpyuuta/src/types.ts
+++ b/packages/konpyuuta/src/types.ts
@@ -66,12 +66,19 @@ export interface WallPost {
   createdAt: number
 }
 
+export interface UserProfileMetadata {
+  bio?: string
+  favoriteSong?: string
+  links?: Array<{ label: string; url: string }>
+  [key: string]: unknown
+}
+
 export interface UserProfile {
   user_id: string
   username: string
   display_name: string
   avatar_url: string
-  metadata: Record<string, unknown>
+  metadata: UserProfileMetadata
 }
 
 export interface SocialService {

--- a/services/dream-npc-go/npc/chat.go
+++ b/services/dream-npc-go/npc/chat.go
@@ -36,7 +36,7 @@ func init() {
 		engine, err := dualmem.New(dualmem.Config{
 			SQLitePath:        dbPath,
 			EmbeddingProvider: dualmem.NewGeminiEmbedder(apiKey, 768),
-			Classifier:        dualmem.NewGeminiClassifier(apiKey, nil),
+			Classifier:        dualmem.NewGeminiClassifier(apiKey, dualmem.NPCSectors()),
 			Summarizer:        dualmem.NewGeminiSummarizer(apiKey, ""),
 		})
 		if err != nil {


### PR DESCRIPTION
## Summary

- **KonpyuuTA React rewrite**: Replaced the Astro/iframe-based OS (OS5000k) with a React component library that embeds directly in client-3d. No more postMessage bridge or iframe nesting — apps are React components with shared Zustand state and context-based access to auth/network/playlists.
- **Full app suite**: KonpyuuTADesktop, AppManager, Calendar, FileManager, Lynx browser, ManViewer, ProcessMonitor, Settings, NetscapeNavigator (MutantTube + MutantBook)
- **MutantTube**: YouTube search, inline playback, playlist CRUD, import. Homepage uses random word combos sorted by lowest view count.
- **MutantBook**: Early Facebook-style profile viewer with wall posts (friend-only posting)
- **CDE theme**: Full Common Desktop Environment look with XPM icon support, draggable/resizable windows, palette system
- **Fix NPC crash**: Nil pointer dereference in dualmem GeminiClassifier when chatting with Lily — passed `NPCSectors()` instead of `nil`
- **Fix Hetzner deploy**: Updated Dockerfile.server to reference renamed `packages/konpyuuta/` (was `os5000k`)

## Test plan

- [ ] Run `pnpm -r build` to verify all packages build
- [ ] Start full stack locally, open KonpyuuTA in-world and test app navigation
- [ ] Chat with Lily NPC — verify no crash
- [ ] Deploy to Hetzner — verify Docker build succeeds
- [ ] Test MutantTube search/playback and MutantBook wall posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)