### PR TITLE
docs: remove stale konpyuuta build step, update docs to v2 reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Multiplayer virtual world. Monorepo: `client-3d` (React/R3F/Vite), `server` (Col
 - Auth: Nakama (email/guest) → JWT → `nakamaToken` in Colyseus join options → server verifies via `lib/verifyNakamaToken.ts`
 - Network: `client-3d/src/network/NetworkManager.ts` — singleton via `getNetwork()`
 - State: `server/rooms/schema/OfficeState.ts` (authoritative), types in `types/`
-- KonpyuuTA: in-world mini-OS with postMessage bridge to main app — see `docs/architecture/konpyuuta.md`
+- KonpyuuTA: in-world mini-OS — React desktop rendered by client-3d; main-app data injected as services via `KonpyuuTAProvider` — see `docs/architecture/konpyuuta.md`
 - Deployment: Cloudflare Pages (client-3d), Hetzner (server/Nakama)
 
 ## Dev Setup
@@ -16,9 +16,8 @@ Multiplayer virtual world. Monorepo: `client-3d` (React/R3F/Vite), `server` (Col
 ```bash
 docker compose -f docker-compose.dev.yml up -d  # Nakama + Postgres
 export NAKAMA_ENCRYPTION_KEY=clubmutant_dev_encryption_key_32ch
-pnpm --filter @club-mutant/konpyuuta build       # build KonpyuuTA before client
 cd server && pnpm dev
-cd client-3d && pnpm dev
+cd client-3d && pnpm dev   # KonpyuuTA needs no prebuild — Vite consumes it as TS source
 ```
 
 ## Cross-Package Recipes
@@ -37,9 +36,10 @@ cd client-3d && pnpm dev
 3. Server proxies NPC chat via HTTP from `server/src/rooms/ClubMutant.ts`
 
 ### Adding a KonpyuuTA app
-1. Create `packages/konpyuuta/static/apps/yourapp.html`
-2. Register in `client-3d/src/ui/konpyuuta/appRegistry.ts`
-3. Communication with main client via postMessage bridge (`packages/konpyuuta/src/bridge-sdk.ts`)
+1. Create the React component in `packages/konpyuuta/src/components/apps/YourApp.tsx`
+2. Add a case in `packages/konpyuuta/src/components/AppRouter.tsx`
+3. Add a desktop icon entry in `packages/konpyuuta/src/stores/desktopStore.ts` (SVG in `packages/konpyuuta/public/icons/apps/`)
+4. For main-app data (profiles, playlists, messaging), use the services injected via `KonpyuuTAProvider` in `client-3d/src/ui/konpyuuta/KonpyuuTAShell.tsx`
 
 ### Adding a Nakama RPC
 1. Write handler in `nakama/modules/index.js` (**ES5 only!**)
@@ -63,9 +63,9 @@ cd client-3d && pnpm dev
 - **Forbidden:** const, let, arrow functions, template literals, destructuring, for...of, classes, async/await
 - Code silently fails with modern syntax. Test by restarting the Nakama container.
 
-### KonpyuuTA (vanilla JS)
-- Modern JS is fine (not ES5-restricted like Nakama)
-- Runs in iframes — communicates via postMessage bridge only
+### KonpyuuTA (React/TypeScript)
+- No build step — `package.json` `exports` point at `./src/*.ts`; client-3d's Vite compiles it directly
+- Apps are React components rendered in the shell (no iframes); main-app access goes through injected services, not postMessage
 
 ## Conventions
 
@@ -76,8 +76,7 @@ cd client-3d && pnpm dev
 
 - `client-3d` — React/R3F frontend
 - `server` — Colyseus game server
-- `client-dream` — Dream mode client
-- `packages/konpyuuta` — In-world OS (esbuild, postMessage bridge)
+- `packages/konpyuuta` — In-world OS (React desktop, consumed as TS source)
 - `packages/acs-web` — ACS character system (WASM)
 - `types` — Shared TypeScript types
 - `loadtest` — Load testing tools

--- a/docs/architecture/konpyuuta.md
+++ b/docs/architecture/konpyuuta.md
@@ -1,5 +1,7 @@
 # KonpyuuTA — In-World Operating System
 
+> **⚠️ Partially stale — describes KonpyuuTA v1.** The package is now v2.0.0: a React package consumed as TypeScript source (no build step, no iframes, no postMessage bridge). Apps are React components in `packages/konpyuuta/src/components/apps/`, routed by `AppRouter.tsx`, with desktop icons registered in `stores/desktopStore.ts`. Main-app data (profiles, playlists, messaging) is injected as services through `KonpyuuTAProvider` — see `client-3d/src/ui/konpyuuta/KonpyuuTAShell.tsx`. The "Package & Dev Setup" section below is current; sections mentioning `static/`, `build.mjs`, `bridge-sdk.ts`, or iframe apps are historical.
+
 ## Overview
 
 KonpyuuTA is an in-world mini-OS that opens when players interact with computer terminals in Club Mutant. It uses a **React-based shell** (window manager, taskbar, desktop) with a DOS/BIOS-style boot sequence. Apps are vanilla JS HTML files loaded as single-level iframes. A **postMessage bridge** connects apps to the main Club Mutant app — giving them access to player profiles, friends, direct messaging, playlists, wall posts, and YouTube search.
@@ -136,12 +138,11 @@ The homepage generates 3 random search queries from word pools (e.g. "backyard f
   - Fields: `otherUserId`, `otherUsername`, `lastMessagePreview`, `lastMessageAt`, `unreadCount`
   - Updated atomically on every send/receive
 
-## Build System
+## Package & Dev Setup
 
-- **Package**: `@club-mutant/konpyuuta` in `packages/konpyuuta/`
-- **Build**: `node build.mjs` — copies `static/` to `dist/`, compiles `bridge-sdk.ts` to IIFE with esbuild, injects bridge script into each `apps/*.html`
-- **Dev**: Vite plugin (`client-3d/vite.config.ts`) serves `dist/` at `/konpyuuta/` in dev, copies to `client-3d/dist/konpyuuta/` in production
-- **Deployment**: Cloudflare Pages `_redirects` has passthrough rule `/konpyuuta/* /konpyuuta/:splat 200`
+- **Package**: `@club-mutant/konpyuuta` in `packages/konpyuuta/` (v2.0.0)
+- **No build step**: `package.json` has no `build` script — its `exports` point at `./src/*.ts` and client-3d's Vite compiles the TypeScript source directly
+- **Static assets**: `packages/konpyuuta/public/` (icons, backdrops, palettes) — the `konpyuuta-static` plugin in `client-3d/vite.config.ts` serves it in dev and copies it into the Vite output dir for production builds
 
 ## Key Files
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -49,7 +49,7 @@ Root
 ```
 types ──→ server        (imports @club-mutant/types)
 types ──→ client-3d     (imports @club-mutant/types)
-konpyuuta → client-3d   (iframe embed, must build konpyuuta first)
+konpyuuta → client-3d   (consumed as TS source — no build step; Vite compiles it)
 acs-web → client-3d     (WASM import)
 ```
 
@@ -65,8 +65,8 @@ youtube-api ──HTTP───→ pot-provider     (YouTube PO tokens)
 
 ### Build order
 1. `types` (no deps)
-2. `packages/konpyuuta` + `packages/acs-web` (no deps on workspace packages)
-3. `server`, `client-3d` (depend on types, konpyuuta)
+2. `packages/acs-web` (no deps on workspace packages)
+3. `server`, `client-3d` (depend on types; client-3d compiles `packages/konpyuuta` source directly — no separate build)
 
 ## Services
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": ".eslintrc.js",
   "scripts": {
     "start": "cd server && npm run start",
-    "dev": "docker compose -f docker-compose.dev.yml up -d && pnpm --filter @club-mutant/konpyuuta build && concurrently -k -n server,client,youtube,dream-npc -c blue,green,yellow,magenta \"cd server && DREAM_NPC_SERVICE_URL=http://localhost:4002 pnpm start\" \"cd client-3d && pnpm dev\" \"cd services/youtube-api && go run .\" \"cd services/dream-npc-go && PORT=4002 go run .\"",
-    "dev:no-docker": "pnpm --filter @club-mutant/konpyuuta build && concurrently -k -n server,client,youtube,dream-npc -c blue,green,yellow,magenta \"cd server && DREAM_NPC_SERVICE_URL=http://localhost:4002 pnpm start\" \"cd client-3d && pnpm dev\" \"cd services/youtube-api && go run .\" \"cd services/dream-npc-go && PORT=4002 go run .\"",
+    "dev": "docker compose -f docker-compose.dev.yml up -d && concurrently -k -n server,client,youtube,dream-npc -c blue,green,yellow,magenta \"cd server && DREAM_NPC_SERVICE_URL=http://localhost:4002 pnpm start\" \"cd client-3d && pnpm dev\" \"cd services/youtube-api && go run .\" \"cd services/dream-npc-go && PORT=4002 go run .\"",
+    "dev:no-docker": "concurrently -k -n server,client,youtube,dream-npc -c blue,green,yellow,magenta \"cd server && DREAM_NPC_SERVICE_URL=http://localhost:4002 pnpm start\" \"cd client-3d && pnpm dev\" \"cd services/youtube-api && go run .\" \"cd services/dream-npc-go && PORT=4002 go run .\"",
     "heroku-postbuild": "npm i && cd types && npm i && cd ../server && tsc --project tsconfig.server.json",
     "test": "echo \"Error: no test specified\" && exit 1",
     "build:models": "node scripts/build-models.mjs",


### PR DESCRIPTION
## Summary

`packages/konpyuuta` v2.0.0 has no `build` script — its `exports` point at `./src/*.ts` and client-3d's Vite compiles the TypeScript source directly (the `konpyuuta-static` plugin in `client-3d/vite.config.ts` serves/copies `public/` assets). The documented `pnpm --filter @club-mutant/konpyuuta build` step was a silent no-op ("None of the selected packages has a 'build' script", exit 0).

- **CLAUDE.md** — remove the build step from Dev Setup; fix the "Adding a KonpyuuTA app" recipe (was `static/apps/*.html` + `appRegistry.ts` + `bridge-sdk.ts`, none of which exist — now `src/components/apps/`, `AppRouter.tsx`, `desktopStore.ts`, services via `KonpyuuTAProvider`); update the language-conventions section (React/TS, no iframes/postMessage) and architecture bullet; drop the removed `client-dream` package from the workspace list
- **package.json** — remove the dead build step from the root `dev` and `dev:no-docker` scripts
- **docs/architecture/overview.md** — fix the dependency graph ("iframe embed, must build konpyuuta first") and build order
- **docs/architecture/konpyuuta.md** — replace the "Build System" section with an accurate "Package & Dev Setup"; add a banner marking the remaining v1 bridge/iframe sections as historical (full v2 rewrite tracked as a follow-up)

## Verification

- `packages/konpyuuta/package.json` has no `scripts` key at all — no build script exists
- Root `package.json` parses as valid JSON
- Grep sweep: no remaining `konpyuuta build` / `build.mjs` / `static/` / `bridge-sdk` references outside the banner-covered historical sections of konpyuuta.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)