### PR TITLE
fix(youtube-api): copy cookies instead of symlinking into read-only mount

### DIFF
--- a/services/youtube-api/main.go
+++ b/services/youtube-api/main.go
@@ -572,13 +572,19 @@ func warmupYtDlp() {
 func initCookiesFile() {
 	// Prefer volume-mounted file (no env var needed, easy to update via scp)
 	if _, err := os.Stat(cookiesMountPath); err == nil {
-		// Symlink mounted file to the path yt-dlp reads from
-		os.Remove(cookiesFilePath)
-		if err := os.Symlink(cookiesMountPath, cookiesFilePath); err != nil {
-			log.Printf("[cookies] Failed to symlink mounted cookies: %v", err)
+		// Copy (not symlink) to a writable path: yt-dlp rewrites the cookie jar on
+		// exit, and a symlink into the read-only mount makes every run fail with EROFS
+		data, err := os.ReadFile(cookiesMountPath)
+		if err != nil {
+			log.Printf("[cookies] Failed to read mounted cookies: %v", err)
 			return
 		}
-		log.Println("[cookies] Using volume-mounted cookies file")
+		os.Remove(cookiesFilePath)
+		if err := os.WriteFile(cookiesFilePath, data, 0o600); err != nil {
+			log.Printf("[cookies] Failed to copy mounted cookies: %v", err)
+			return
+		}
+		log.Println("[cookies] Using writable copy of volume-mounted cookies file")
 		return
 	}
 


### PR DESCRIPTION
## Problem

Production proxy resolves are 500ing for any uncached video (cached videos stream fine). Two stacked causes found in the VPS logs:

1. **`/tmp/youtube_cookies.txt` is a symlink into the `:ro` cookies mount.** Current yt-dlp rewrites the cookie jar on exit, hits `OSError: [Errno 30] Read-only file system`, and exits 1 — so even successful cookie-path resolves are reported as failures. This PR fixes that: `initCookiesFile()` now copies the mounted file to a writable path instead of symlinking.

2. **yt-dlp in the deployed image is `2026.02.04`** (pip-installed at image build time, last built months ago) → `ERROR: Requested format is not available` on both resolve paths. Not a code change — fixed at deploy time by rebuilding without cache:

```bash
cd apps/club-mutant && git pull
docker compose -f deploy/hetzner/docker-compose.yml --env-file deploy/hetzner/.env build --no-cache youtube-api
docker compose -f deploy/hetzner/docker-compose.yml --env-file deploy/hetzner/.env up -d youtube-api
```

## Verification

- `go build ./...` clean
- After deploy: `curl -sI "https://yt.mutante.club/proxy/<uncached-id>?audioOnly=true"` should return 200 and logs should show no EROFS traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)