### PR TITLE
NPC automaton DJ (Phase 1) + DJ queue hardening (audit F1-F14)

### DIFF
--- a/client-3d/src/network/NetworkManager.ts
+++ b/client-3d/src/network/NetworkManager.ts
@@ -525,8 +525,9 @@ export class NetworkManager {
     this.room?.send(Message.DJ_SKIP_TURN, {})
   }
 
-  djTurnComplete() {
-    this.room?.send(Message.DJ_TURN_COMPLETE, {})
+  // streamId lets the server reject stale/duplicate completions (audit F4)
+  djTurnComplete(streamId?: number) {
+    this.room?.send(Message.DJ_TURN_COMPLETE, { streamId })
   }
 
   // Trampoline jump

--- a/client-3d/src/network/messages/djQueueHandlers.ts
+++ b/client-3d/src/network/messages/djQueueHandlers.ts
@@ -41,6 +41,13 @@ export function wireDJQueueHandlers(room: Room<RoomState>): void {
     console.warn('[network] Schema callbacks for djQueue failed:', err)
   }
 
+  // F9: the 3D client syncs the DJ queue exclusively via the schema callbacks
+  // above, but the server still broadcasts DJ_QUEUE_UPDATED for the legacy 2D
+  // client (client/src/services/Network.ts consumes it and is not part of the
+  // pnpm workspace, so it can't be refactored here). Register a no-op so
+  // Colyseus stops logging "onMessage ... not registered" on every mutation.
+  room.onMessage(Message.DJ_QUEUE_UPDATED, () => {})
+
   // Per-player queue playlist updates
   room.onMessage(Message.ROOM_QUEUE_PLAYLIST_UPDATED, (payload: { items: any[] }) => {
     useBoothStore.getState().setQueuePlaylist(

--- a/client-3d/src/network/messages/musicHandlers.ts
+++ b/client-3d/src/network/messages/musicHandlers.ts
@@ -45,8 +45,38 @@ export function wireMusicHandlers(room: Room<RoomState>, timeSync: TimeSync | nu
     (data: { streamId: number; startTime: number; serverNowMs: number }) => {
       const store = useMusicStore.getState()
 
-      // Ignore ticks for a different stream
-      if (!store.stream.isPlaying || store.stream.streamId !== data.streamId) return
+      // F13: a tick carrying a NEWER streamId than the store means this client
+      // missed START_MUSIC_STREAM (dropped message / transient handler error).
+      // Rehydrate from schema state — which the tick confirms is current —
+      // instead of staying silent until the next track.
+      if (!store.stream.isPlaying || data.streamId > (store.stream.streamId ?? 0)) {
+        const ms = (room.state as any)?.musicStream
+        if (
+          ms &&
+          ms.status === 'playing' &&
+          ms.currentLink &&
+          !ms.isAmbient &&
+          (ms.streamId ?? 0) === data.streamId
+        ) {
+          const rehydratedStart = timeSync?.ready
+            ? timeSync.toClientTime(data.startTime)
+            : data.startTime
+          console.log('[Music] Tick carries newer streamId — rehydrating missed stream')
+          store.setStream({
+            currentLink: ms.currentLink,
+            currentTitle: ms.currentTitle ?? null,
+            currentDjName: ms.currentDj?.name ?? null,
+            startTime: rehydratedStart,
+            duration: ms.duration ?? 0,
+            isPlaying: true,
+            streamId: ms.streamId ?? 0,
+          })
+        }
+        return
+      }
+
+      // Ignore stale ticks for an older stream
+      if (store.stream.streamId !== data.streamId) return
 
       // Recompute client-local startTime from this tick's authoritative server time
       const clientStartTime = timeSync?.ready

--- a/client-3d/src/network/messages/musicHandlers.ts
+++ b/client-3d/src/network/messages/musicHandlers.ts
@@ -15,10 +15,13 @@ export function wireMusicHandlers(room: Room<RoomState>, timeSync: TimeSync | nu
       // Skip ambient background streams — no DJ is playing
       if (ms.isAmbient) return
 
-      // Convert server startTime to client time using clock sync
+      // Convert server startTime to client time using clock sync. Before
+      // TimeSync is ready, derive startTime from the server-computed offset
+      // (F11/F12): that value is skew-free (only off by one-way latency),
+      // unlike the raw server-clock startTime.
       const clientStartTime = timeSync?.ready
         ? timeSync.toClientTime(ms.startTime ?? 0)
-        : (ms.startTime ?? 0)
+        : Date.now() - (data.offset ?? 0) * 1000
 
       useMusicStore.getState().setStream({
         currentLink: ms.currentLink ?? null,
@@ -69,11 +72,17 @@ export function wireMusicHandlers(room: Room<RoomState>, timeSync: TimeSync | nu
       const ms = rs?.musicStream
       if (!ms || ms.status !== 'playing' || !ms.currentLink || ms.isAmbient) return
 
-      // Skip if START_MUSIC_STREAM message already set this stream
       const store = useMusicStore.getState()
-      if (store.stream.isPlaying && store.stream.streamId === (ms.streamId ?? 0)) return
-
       const clientStartTime = timeSync.toClientTime(ms.startTime ?? 0)
+
+      // START_MUSIC_STREAM may have set this stream BEFORE TimeSync was ready
+      // (offset-derived startTime, off by one-way latency). Now that sync
+      // samples exist, refresh startTime with the skew-corrected value
+      // instead of skipping the stream entirely (F11).
+      if (store.stream.isPlaying && store.stream.streamId === (ms.streamId ?? 0)) {
+        store.setStream({ startTime: clientStartTime })
+        return
+      }
 
       store.setStream({
         currentLink: ms.currentLink,

--- a/client-3d/src/ui/DjQueuePanel.tsx
+++ b/client-3d/src/ui/DjQueuePanel.tsx
@@ -406,7 +406,7 @@ export function DjQueuePanel() {
                   {isCurrentDJ ? '● you are the DJ' : myQueuePos > 0 ? `your queue spot: #${myQueuePos}` : 'you are not in the queue'}
                 </span>
                 {djQueue.length > 0 && (
-                  <span className="text-white/40">{djQueue[0]?.sessionId === mySessionId ? 'now playing' : `playing: ${djQueue[0]?.name}`}</span>
+                  <span className="text-white/40">{djQueue[0]?.sessionId === mySessionId ? 'now playing' : `playing: ${djQueue[0]?.name}${djQueue[0]?.sessionId?.startsWith('npc-dj:') ? ' [BOT]' : ''}`}</span>
                 )}
               </div>
             </div>

--- a/client-3d/src/ui/NowPlaying.tsx
+++ b/client-3d/src/ui/NowPlaying.tsx
@@ -56,7 +56,7 @@ export function NowPlaying() {
     } else {
       if (!isCurrentDJ) return
       console.log('[NowPlaying] DJ track ended (streamId=%d), sending djTurnComplete', sid)
-      getNetwork().djTurnComplete()
+      getNetwork().djTurnComplete(sid)
     }
   }, [isCurrentDJ, isJukeboxMode])
 
@@ -187,7 +187,9 @@ export function NowPlaying() {
             )}
 
             <button
-              onClick={() => getNetwork().djTurnComplete()}
+              onClick={() =>
+                getNetwork().djTurnComplete(useMusicStore.getState().stream.streamId)
+              }
               className="w-7 h-7 flex items-center justify-center bg-white/10 hover:bg-white/20 border border-white/15 rounded transition-colors"
               title="Skip to next"
             >

--- a/client-3d/src/ui/NowPlaying.tsx
+++ b/client-3d/src/ui/NowPlaying.tsx
@@ -97,7 +97,9 @@ export function NowPlaying() {
 
   // Build "up next" text (DJ queue mode only — jukebox returns early above)
   const nextDJ = djQueue.length > 1 ? djQueue[1] : null
-  const upNextText = nextDJ ? `Up next: ${nextDJ.name}` : null
+  const upNextText = nextDJ
+    ? `Up next: ${nextDJ.name}${nextDJ.sessionId?.startsWith('npc-dj:') ? ' [BOT]' : ''}`
+    : null
 
   // Time display
   const timeText =

--- a/client-3d/src/ui/NowPlaying.tsx
+++ b/client-3d/src/ui/NowPlaying.tsx
@@ -71,6 +71,58 @@ export function NowPlaying() {
     }
   }, [stream.currentLink, stream.startTime, stream.isPlaying])
 
+  // F10: re-apply the late-join seek once the player is actually ready.
+  // A seekTo issued before the YouTube iframe is ready can silently expire
+  // (react-player's pending seek has a ~5s TTL — slow networks or blocked
+  // autoplay exceed it), leaving playback at 0:00 with no correction.
+  const handleReadyOrStart = useCallback(() => {
+    const s = useMusicStore.getState().stream
+    const player = playerRef.current
+    if (!s.isPlaying || !s.startTime || !player) return
+
+    const expectedSec = (Date.now() - s.startTime) / 1000
+    const actualSec = player.getCurrentTime?.() ?? 0
+
+    if (expectedSec > 1 && Math.abs(actualSec - expectedSec) > 2) {
+      console.log(
+        '[NowPlaying] Player ready %ds behind stream — re-seeking to %ds',
+        Math.round(expectedSec - actualSec),
+        Math.round(expectedSec)
+      )
+      player.seekTo(expectedSec, 'seconds')
+    }
+  }, [])
+
+  // F10: periodic position-drift check — compares the ACTUAL player position
+  // against expected elapsed and re-seeks when they diverge. Catches expired
+  // initial seeks and YouTube buffering stalls, which the timestamp-only tick
+  // correction in musicHandlers.ts can never see.
+  useEffect(() => {
+    if (!isPlaying) return
+
+    const id = setInterval(() => {
+      const s = useMusicStore.getState().stream
+      const player = playerRef.current
+      if (!s.isPlaying || !s.startTime || !player) return
+
+      const expectedSec = (Date.now() - s.startTime) / 1000
+      const actualSec = player.getCurrentTime?.()
+
+      if (typeof actualSec !== 'number' || !isFinite(actualSec)) return
+
+      if (Math.abs(actualSec - expectedSec) > 2) {
+        console.log(
+          '[NowPlaying] Position drift: expected %ds, actual %ds — resyncing',
+          Math.round(expectedSec),
+          Math.round(actualSec)
+        )
+        player.seekTo(expectedSec, 'seconds')
+      }
+    }, 5000)
+
+    return () => clearInterval(id)
+  }, [isPlaying, stream.streamId])
+
   // Track elapsed time and total duration
   useEffect(() => {
     if (!isPlaying || !stream.startTime) {
@@ -123,6 +175,8 @@ export function NowPlaying() {
           width={1}
           height={1}
           onEnded={handleEnded}
+          onReady={handleReadyOrStart}
+          onStart={handleReadyOrStart}
           config={{
             playerVars: {
               autoplay: 1,
@@ -153,6 +207,8 @@ export function NowPlaying() {
             width={1}
             height={1}
             onEnded={handleEnded}
+            onReady={handleReadyOrStart}
+            onStart={handleReadyOrStart}
             config={{
               playerVars: {
                 autoplay: 1,

--- a/docs/plans/2026-07-05-dj-queue-audit.md
+++ b/docs/plans/2026-07-05-dj-queue-audit.md
@@ -1,0 +1,238 @@
+# DJ Queue Subsystem Audit — 2026-07-05
+
+Read-only audit of round-robin rotation correctness and jukebox/late-joiner sync.
+No source files were modified.
+
+**Files traced:**
+- `server/src/rooms/commands/DJQueueCommand.ts` (advanceRotation, markTrackAsPlayed, removeDJFromQueue, all DJ commands)
+- `server/src/rooms/commands/djHelpers.ts` (playTrackForCurrentDJ)
+- `server/src/rooms/commands/RoomQueuePlaylistCommand.ts`
+- `server/src/rooms/ClubMutant.ts` (watchdog, music stream tick, onJoin/onDrop/onLeave, message handler registration)
+- `types/RoomState.ts` (MusicStream, DJQueueEntry, Player schemas)
+- `client-3d/src/network/messages/musicHandlers.ts`, `djQueueHandlers.ts`
+- `client-3d/src/network/TimeSync.ts`, `NetworkManager.ts`
+- `client-3d/src/ui/NowPlaying.tsx`, `client-3d/src/stores/musicStore.ts`
+
+Severity legend: **HIGH** = wrong rotation / audible breakage in normal use; **MED** = stall or wrong-track bookkeeping recoverable by user action; **LOW** = hygiene / rare.
+
+---
+
+## Part 1 — Round-robin rotation correctness
+
+### F1. HIGH / CONFIRMED — `advanceRotation` assumes `djQueue[0]` is the current DJ, but three promotion paths set `currentDjSessionId` without moving that entry to the front
+
+**Where:**
+- `server/src/rooms/commands/DJQueueCommand.ts:52` — `const currentEntry = room.state.djQueue[0]` (rotation always shifts the *front* entry)
+- Promotion paths that do NOT reorder the queue:
+  - `DJQueueCommand.ts:252-256` — `DJQueueJoinCommand`: "No current DJ — set this one as current" (new joiner is pushed to the *end*)
+  - `DJQueueCommand.ts:303-313` — `DJPlayCommand` auto-promote: any queued player becomes current when `currentDjSessionId` is null, regardless of position
+  - `RoomQueuePlaylistCommand.ts:71-79` — `RoomQueuePlaylistAddCommand`: promotes the track-adder when there is no current DJ, regardless of position
+
+`currentDjSessionId` can legitimately be null while the queue is non-empty (`DJQueueCommand.ts:99` — `advanceRotation` sets it null when no DJ has unplayed tracks), so these paths are reachable in normal play.
+
+**Repro:**
+1. DJs A and B join (queue = [A, B]). Both play through all their tracks; `advanceRotation` eventually finds no unplayed tracks → `currentDjSessionId = null`, queue still [A, B] (`DJQueueCommand.ts:97-109`).
+2. B adds a new track → `RoomQueuePlaylistCommand.ts:71-73` promotes B (`currentDjSessionId = B`) while B sits at index 1.
+3. B presses play; the track finishes; client sends `DJ_TURN_COMPLETE` → `advanceRotation`.
+4. Line 52 takes `djQueue[0]` = **A** as "current", shifts A off the front and re-appends A — A is rotated to the back **without ever having a turn**.
+5. `findNextDJWithTracks` scans [B, A]: if B added two tracks, B plays again immediately — **B gets consecutive turns, A is starved/skipped**. If A had unplayed tracks, they're now behind B.
+
+**Fix direction:** make `advanceRotation` rotate the entry matching `state.currentDjSessionId` (findIndex by sessionId) instead of blindly using index 0 — or make every promotion path move the promoted entry to the front (`unshift`) so the invariant "current DJ == djQueue[0]" actually holds. Pick one invariant and enforce it in a single helper.
+
+---
+
+### F2. HIGH / CONFIRMED — `onLeave` dispatches `DJQueueLeaveCommand` without clearing/re-arming the track watchdog → stale watchdog cuts the next DJ's track short
+
+**Where:**
+- `server/src/rooms/ClubMutant.ts:1345-1349` — `onLeave` dispatches `DJQueueLeaveCommand` directly, with no `clearTrackWatchdog()` / `startWatchdogIfPlaying()` around it.
+- Contrast with the explicit `DJ_QUEUE_LEAVE` message handler at `ClubMutant.ts:1022-1027`, which does clear + re-arm.
+- `DJQueueCommand.ts:162-175` — `removeDJFromQueue` auto-starts the next DJ's track (`playTrackForCurrentDJ`) inside that dispatch.
+
+**Repro:**
+1. DJ A is mid-track (watchdog armed for A's track duration + 10 s, `ClubMutant.ts:138-139`).
+2. A closes the tab / disconnects with a consented leave → `onLeave` fires → `removeDJFromQueue` stops A's stream and auto-plays DJ B's track (`DJQueueCommand.ts:145-175`).
+3. The watchdog from **A's** track is still armed. When it fires (`ClubMutant.ts:141-162`), `ms.status === 'playing'` (B's track) → it dispatches `DJTurnCompleteCommand` for the *current* DJ (B) → **B's track is cut off at an arbitrary point** (wherever A's old timer landed) and rotation advances early.
+4. Symmetrically, if the old watchdog had already fired or was never armed, B's auto-started track runs with **no watchdog at all** (see F3 for consequence).
+
+Note: the involuntary-disconnect path is delayed by `allowReconnection(client, 60)` (`ClubMutant.ts:1279-1291`), but `onLeave` still eventually runs with the same missing watchdog handling; the consented-leave path hits it immediately.
+
+**Fix direction:** wrap the `onLeave` dispatch in the same `clearTrackWatchdog()` / `startWatchdogIfPlaying()` pair used by the message handler — better, move watchdog arm/clear *into* `playTrackForCurrentDJ` / the stop paths so it can't be forgotten by any caller.
+
+---
+
+### F3. HIGH / CONFIRMED — watchdog callback never re-arms after auto-advancing → next track has no watchdog backstop
+
+**Where:** `server/src/rooms/ClubMutant.ts:141-162`. The `setTimeout` callback dispatches `DJTurnCompleteCommand` (which runs `advanceRotation` → `playTrackForCurrentDJ`, starting a new track) but never calls `startWatchdogIfPlaying()` afterwards. All *message*-driven paths re-arm (`ClubMutant.ts:1045-1049`); the timer-driven path does not.
+
+**Repro (rotation stall):**
+1. Single DJ A with tracks [T1, T2]. A's tab is closed mid-T1 (within the 60 s reconnection window, A is still in `players` and still current).
+2. Nobody sends `DJ_TURN_COMPLETE` (only the current DJ's client reports in DJ mode — `client-3d/src/ui/NowPlaying.tsx:56-60`). Watchdog fires at T1-duration + 10 s → advances → T2 starts playing.
+3. T2 now has **no watchdog** and no client to report its end → `musicStream.status` stays `'playing'` indefinitely (until A's reconnection window expires and `onLeave` cleans up, or some unrelated DJ message handler incidentally calls `startWatchdogIfPlaying()`).
+4. With two DJs where the current DJ's client silently fails (backgrounded tab whose `onEnded` never fires, autoplay-blocked player), the same one-shot degradation applies: watchdog saves the first track, then the safety net is gone.
+
+**Fix direction:** call `startWatchdogIfPlaying()` at the end of the watchdog callback (after the dispatch) — or, per F2, arm the watchdog inside `playTrackForCurrentDJ` itself so every started track is covered regardless of trigger path.
+
+---
+
+### F4. MED-HIGH / CONFIRMED — no streamId dedupe on `DJ_TURN_COMPLETE` → double-advance when the rotation wraps to the same DJ
+
+**Where:**
+- `DJQueueCommand.ts:370-399` — `DJTurnCompleteCommand`'s only dedupe is the `currentDjSessionId === client.sessionId` guard, which is useless when `advanceRotation` wraps back to the *same* session (single DJ, or others have no unplayed tracks).
+- Contrast: jukebox mode deduplicates via `streamId` (`ClubMutant.ts:1136-1144`), DJ mode does not.
+- Client-side dedupe (`NowPlaying.tsx:43-51`, `lastEndedStreamIdRef`) only covers duplicate `onEnded` events on one client; it does not cover the watchdog racing the client, nor the manual "▶▶" button (`NowPlaying.tsx:188`) which sends `DJ_TURN_COMPLETE` directly with no streamId.
+
+**Repro:**
+1. Single DJ A, tracks [T1, T2]. T1 plays. A's playback lags/buffers so the client `onEnded` fires > 10 s after the server-side duration elapses.
+2. Watchdog fires first: marks T1 played, `advanceRotation` wraps to A, starts T2 (streamId++).
+3. A's late `DJ_TURN_COMPLETE` (for T1) now arrives. Guard passes — A is still the current DJ. `markTrackAsPlayed` marks **T2** (currently playing, at index 0) as played, `advanceRotation` runs again → no unplayed tracks left → **T2 is killed seconds after starting and the room goes silent**.
+4. Same outcome if the user clicks "▶▶" right as the track naturally ends (two `DJ_TURN_COMPLETE`s in flight).
+
+**Fix direction:** include `streamId` in the `DJ_TURN_COMPLETE` payload (client already has it) and have `DJTurnCompleteCommand` ignore completions whose streamId ≠ `state.musicStream.streamId`, mirroring the jukebox pattern.
+
+---
+
+### F5. MED / CONFIRMED — `removeDJFromQueue` promotes the next DJ "regardless of tracks" and `playTrackForCurrentDJ` silently no-ops → silent stall after the current DJ leaves
+
+**Where:**
+- `DJQueueCommand.ts:162-175` — promotes `djQueue[0]` unconditionally; auto-plays only if `roomQueuePlaylist.length > 0` (a *length* check, not an unplayed check).
+- `djHelpers.ts:17-25` — `playTrackForCurrentDJ` returns silently when the DJ has no **unplayed** track.
+- Asymmetry: `advanceRotation` skips DJs without unplayed tracks (`findNextDJWithTracks`, `DJQueueCommand.ts:21-33`); `removeDJFromQueue` does not.
+
+**Repro:**
+1. DJ A is playing; DJ B waits in queue having already played all their tracks in a previous cycle (played flags still true — only `DJPlayCommand` resets them, `DJQueueCommand.ts:327-336`).
+2. A leaves. `removeDJFromQueue` stops the music, promotes B, calls `playTrackForCurrentDJ` (B's playlist length > 0) → finds no unplayed track → returns.
+3. Room is silent, `status = 'waiting'`, B is current. Nothing recovers automatically; B must notice and press ▶ (which triggers the loop-reset in `DJPlayCommand`).
+
+**Fix direction:** on leave-promotion, reuse the `advanceRotation` selection logic (skip-to-next-with-unplayed) or apply the same "all played → reset flags" loop-reset that `DJPlayCommand` does before auto-playing.
+
+---
+
+### F6. MED / CONFIRMED — a current DJ with no tracks blocks the rotation; other queued DJs cannot start playback
+
+**Where:**
+- `DJQueueCommand.ts:249-256` — first joiner becomes current even with an empty playlist.
+- `DJQueueCommand.ts:303-313` — `DJPlayCommand` rejects any non-current player whenever `currentDjSessionId` is non-null (auto-promote only fires when it's null).
+- No watchdog runs while nothing is playing, so there is no timer to break the deadlock.
+
+**Repro:**
+1. A joins the DJ queue with no tracks → set as current.
+2. B joins with a full playlist. B's UI shows the play button (`NowPlaying.tsx:139` — `isInQueue && !isPlaying`), B presses ▶ → server rejects: "Play rejected - not current DJ" (`DJQueueCommand.ts:310-312`).
+3. Nothing plays until A adds tracks and plays, presses skip (`DJSkipTurnCommand`), or leaves. A idle/AFK A stalls the booth indefinitely. Same state is reachable via F5's promotion of a trackless DJ.
+
+**Fix direction:** when the current DJ has no unplayed tracks and another queued DJ requests play, pass the turn (or run `findNextDJWithTracks` on a timer / on `DJ_PLAY`). Alternatively require ≥1 track to occupy "current" status.
+
+---
+
+### F7. MED / CONFIRMED — `markTrackAsPlayed` marks `roomQueuePlaylist[0]`, not the track that actually played
+
+**Where:**
+- `DJQueueCommand.ts:118-132` — always takes index 0.
+- `djHelpers.ts:17-25` — `playTrackForCurrentDJ` plays the *first unplayed* track, which can be at index > 0.
+- The guards protecting "the currently playing track" also hardcode index 0: remove guard `RoomQueuePlaylistCommand.ts:98-105`, reorder guard `RoomQueuePlaylistCommand.ts:129-137`.
+
+**Repro:**
+1. While stopped (`status = 'waiting'`), DJ A reorders their playlist so a *played* track sits at index 0 and an unplayed track at index 1 (reorder guard only applies while playing).
+2. A presses ▶. `playTrackForCurrentDJ` plays index 1 (first unplayed).
+3. Track ends → `markTrackAsPlayed` marks **index 0** (already played) and rotates it to the bottom; the track that actually played remains `played = false` → it plays again next turn. Meanwhile the remove/reorder guards were protecting the wrong item, so the actually-playing track could also be removed mid-play.
+
+**Fix direction:** record the playing track's id on the musicStream (or room) when `playTrackForCurrentDJ` starts it, and have `markTrackAsPlayed` + the remove/reorder guards target that id instead of index 0.
+
+---
+
+### F8. LOW / CONFIRMED — played-flag reset only happens on explicit `DJ_PLAY`; a full cycle ends in silence with DJs still at the booth
+
+**Where:** `DJQueueCommand.ts:97-109` (advanceRotation stops when no DJ has unplayed tracks) and `DJQueueCommand.ts:327-336` (reset lives only in `DJPlayCommand`).
+
+**Scenario:** queue [A, B]; both playlists fully played once → music stops, `currentDjSessionId = null`, DJs remain in queue. Recovery requires a human to press ▶ (which promotes + resets). May be intentional ("no infinite loop without consent"), but combined with F1 the null-current state it creates is what corrupts rotation order. If auto-looping is desired, reset flags in `advanceRotation` when *every* queued DJ is exhausted.
+
+---
+
+### F9. LOW / CONFIRMED — `DJ_QUEUE_UPDATED` broadcasts are dead traffic to the 3D client
+
+**Where:** server broadcasts on every mutation (`DJQueueCommand.ts:111-114, 183-186, 258-261`; `RoomQueuePlaylistCommand.ts:75-79`), but the client syncs the DJ queue exclusively via schema callbacks (`client-3d/src/network/messages/djQueueHandlers.ts:32-42`) and registers no `onMessage(DJ_QUEUE_UPDATED)`. Colyseus client logs "onMessage … not registered" warnings; bandwidth is wasted (full queue array per event). Fix direction: drop the broadcast or register a no-op handler; schema is already the source of truth (and correctly covers late joiners).
+
+---
+
+## Part 2 — Jukebox / late-joiner sync
+
+**How it works today (traced):**
+- On join, the server sends `START_MUSIC_STREAM` with a server-computed `offset` (`ClubMutant.ts:1264-1270`). Broadcast starts always send `offset: 0` (`djHelpers.ts:43`, `JukeboxCommand.ts:58`).
+- The client **ignores `data.offset` entirely** (`musicHandlers.ts:9-33` never reads it) and instead derives the seek from `ms.startTime`, converted to client clock via `TimeSync` when ready.
+- `NowPlaying.tsx:63-72` seeks to `(Date.now() - stream.startTime) / 1000` when > 1 s.
+- Drift correction: `MUSIC_STREAM_TICK` every 5 s (`ClubMutant.ts:221-235`) → client resyncs `startTime` if timestamp drift > 2 s (`musicHandlers.ts:40-63`), which re-triggers the seek effect.
+- A one-shot `timeSync.onReady` fallback re-reads `room.state.musicStream` for late joiners (`musicHandlers.ts:65-88`).
+- Between-tracks join (`status = 'waiting'`) correctly sends/plays nothing — verified OK.
+
+### F10. HIGH / PLAUSIBLE (mechanism confirmed in code; needs runtime verification of react-player behavior) — late joiners can start at 0:00 when the seek lands before the YouTube player is ready, and nothing ever re-seeks
+
+**Where:** `client-3d/src/ui/NowPlaying.tsx:63-72` and the conditional mount at `NowPlaying.tsx:112-133 / 144-161` (ReactPlayer only mounts once `isPlaying` flips true).
+
+**Chain:**
+1. Late joiner receives `START_MUSIC_STREAM` → store updates → ReactPlayer mounts → the seek effect runs immediately, while the underlying YouTube iframe is still loading.
+2. `react-player`'s `seekTo` before ready stores a `seekOnPlay` value with a ~5 s expiry. If the YT player takes > 5 s to become ready — slow network, or **autoplay blocked pending a user gesture** (common for a fresh page load joining a room with music already playing) — the pending seek expires and playback begins at **0:00**.
+3. Nothing corrects it: the tick drift correction (`musicHandlers.ts:53-61`) compares *store timestamps*, not the actual player position — store `startTime` is already correct, so drift ≈ 0 and no re-seek fires. The listener hears the track from the beginning, out of sync with the room, forever (until the next track).
+
+**Repro:** join a room mid-track on a throttled connection (or before any page interaction so autoplay is deferred); observe playback from 0:00 while `elapsed` in the UI (computed from `startTime`) shows the correct mid-track time — the UI/audio disagreement is the tell.
+
+**Fix direction:** wire `onReady`/`onStart` on ReactPlayer and (re)apply the seek there from `startTime`; optionally add a periodic check comparing `playerRef.getCurrentTime()` against expected elapsed and re-seek when they diverge > N seconds (that would also catch YouTube buffering stalls, which timestamp-only drift correction can never see).
+
+### F11. MED / CONFIRMED — initial offset uses raw server `startTime` before TimeSync is ready, and the onReady fallback deliberately skips the correction
+
+**Where:** `musicHandlers.ts:19-21` (falls back to raw `ms.startTime` when `!timeSync.ready`), `musicHandlers.ts:72-74` (onReady fallback returns early if "START_MUSIC_STREAM message already set this stream" — exactly the case where the skewed value was stored).
+
+**Chain:** the onJoin `START_MUSIC_STREAM` arrives before the first TimeSync sample (probes start at join, first response ≥ 1 RTT later — `TimeSync.ts:19-21`, wiring order `NetworkManager.ts:228-231`). So the stored `startTime` is server-clock, and the seek/elapsed math uses client `Date.now()` (`NowPlaying.tsx:67, 83`) → the initial seek is off by the full client-server clock skew. Skew > 2 s is repaired within ≤ 5 s by the tick handler; **skew ≤ 2 s persists for the whole track** (audible desync between listeners, though bounded). The onReady fallback was built for this moment but its skip-guard excludes the skewed-store case.
+
+**Fix direction:** in the onReady callback, *recompute* `startTime` via `toClientTime` even when the streamId matches (replace the early-return with a startTime refresh), and/or actually use the server-computed `offset` field for the initial seek instead of discarding it. Also worth lowering the 2 s drift threshold once TimeSync is ready.
+
+### F12. LOW / CONFIRMED — server-computed `offset` field is dead code on the wire
+
+`ClubMutant.ts:1266-1269` computes `(now - startTime) / 1000` for late joiners; `djHelpers.ts:43` / `JukeboxCommand.ts:58` / `ClubMutant.ts:218` send `offset: 0`. No client code reads it (`musicHandlers.ts` destructures only `musicStream`). Either consume it (it's skew-free and would fix F11's initial seek) or remove it to avoid the false impression that offset sync is message-driven.
+
+### F13. LOW / PLAUSIBLE — a client that misses `START_MUSIC_STREAM` mid-session stays silent until the next track
+
+`musicHandlers.ts:46` ignores `MUSIC_STREAM_TICK` when `!store.stream.isPlaying || streamId mismatch`, and the schema fallback runs only once at `timeSync.onReady`. Any missed START broadcast after that (transient handler error, message dropped during a reconnect that resumes the same room instance) leaves the client with no recovery path even though ticks carrying `streamId`/`startTime` arrive every 5 s. Fix direction: on a tick whose `streamId` is *ahead* of the store's, re-hydrate the stream from `room.state.musicStream` instead of returning.
+
+### F14. MED / PLAUSIBLE — client-supplied `duration` drives the watchdog; wrong/zero duration breaks the backstop or cuts tracks early
+
+`RoomQueuePlaylistCommand.ts:47` stores whatever `duration` the client sent; `djHelpers.ts:40` copies it to `musicStream.duration`; `startWatchdogIfPlaying` (`ClubMutant.ts:173-179`) arms only when `duration > 0` and fires at `duration + 10 s`. Consequences: duration `0` (client failed to resolve it) → **no watchdog** for that track (combines with F3's stall); duration shorter than the real video → watchdog fires mid-track and force-advances (`ClubMutant.ts:157-160`) — indistinguishable from F2's symptom. Also a trivially spoofable input. Fix direction: validate/clamp duration server-side (e.g., via the youtube-api service metadata already used for prefetch) or treat watchdog expiry more conservatively (verify against `startTime + duration` recomputed at fire time — currently correct only if duration was honest).
+
+---
+
+## Verified OK (explicitly checked, no issue found)
+
+- Single-DJ self-rotation in `advanceRotation` (shift + push + `index > 0` guard) is consistent — no lost entry (`DJQueueCommand.ts:52-96`).
+- `markTrackAsPlayed` on a 1-item playlist (push then shift) is safe (`DJQueueCommand.ts:127-129`).
+- Empty-queue mid-track: last DJ leaving stops the stream and nulls `currentDjSessionId` (`DJQueueCommand.ts:145-152, 176-180`).
+- Late joiners get the DJ queue via schema callbacks, including initial state delivery (`djQueueHandlers.ts:32-42`).
+- Joining between tracks (`status='waiting'`): server sends nothing, client store stays cleared — correct silence, next START covers them.
+- `DJ_TURN_COMPLETE` from non-DJ clients is guarded server-side, and non-DJ clients don't send it anyway (`NowPlaying.tsx:57`).
+- Jukebox-mode track completion has proper streamId dedupe (`ClubMutant.ts:1136-1144`) — the DJ path just never got the same treatment (F4).
+
+## Suggested priority order
+
+1. F1 (rotation invariant) + F4 (streamId on DJ_TURN_COMPLETE) — correctness of turn order.
+2. F2 + F3 — centralize watchdog arm/clear in `playTrackForCurrentDJ`/stop paths; fixes both at once.
+3. F10 + F11/F12 — late-join seek reliability (onReady re-seek + consume server offset).
+4. F5/F6/F7 — stall & bookkeeping fixes (shared root: no single "currently playing track" identity → F7's fix helps F4 too).
+5. F8/F9/F13/F14 — hygiene and hardening.
+
+## Resolutions (2026-07-06)
+
+All 14 findings addressed on the audit's suggested order, one commit per cluster. Line references below are to the post-refactor layout (`djHelpers.ts` holds the rotation helpers, not `DJQueueCommand.ts`).
+
+| # | Status | How |
+|---|--------|-----|
+| F1 | Fixed | `advanceRotation` rotates the entry matching `state.currentDjSessionId` (`findIndex`), never blindly `djQueue[0]`; `queuePosition` re-numbered contiguously. Vitest coverage. |
+| F2 | Fixed | Watchdog clear/re-arm centralized inside `playTrackForCurrentDJ` and every stop/advance path. `ClubMutant.clearTrackWatchdog`/`startWatchdogIfPlaying` remain public. `NpcDjManager.armTrackTimer` still clears the watchdog immediately after playback starts, so its own timer stays the sole timing authority for NPC tracks. |
+| F3 | Fixed | `onLeave` and watchdog-driven advances funnel through the same centralized clear→advance→re-arm path — the double-advance race is gone. |
+| F4 | Fixed | `DJ_TURN_COMPLETE` now carries `streamId` from both client senders (`NowPlaying.tsx` onEnded reporter and ▶▶ skip); server rejects stale/duplicate completions exactly like the jukebox dedupe. Vitest coverage. |
+| F5 | Fixed | Leave-promotion uses the same `findNextDJWithTracks` selection as `advanceRotation` — played flags respected, exhausted DJs skipped. Vitest coverage. |
+| F6 | Fixed | A trackless current DJ no longer blocks the rotation; the turn passes to the next DJ with unplayed tracks. |
+| F7 | Fixed | The currently playing item is recorded by track id; `markTrackAsPlayed` marks that id, not whatever sits at index 0. Vitest coverage. |
+| F8 | Fixed | When every queued DJ is exhausted, `advanceRotation` resets `played` flags and loops the rotation instead of stopping; it still stops when queued DJs have no tracks at all. Vitest coverage. |
+| F9 | Fixed | `client-3d` registers a no-op `DJ_QUEUE_UPDATED` handler (schema callbacks remain the source of truth). Broadcast kept server-side for the legacy 2D client, which is outside the pnpm workspace. |
+| F10 | Fixed — needs runtime verification | Re-seek on ReactPlayer `onReady`/`onStart`; periodic drift check resyncs whenever `getCurrentTime()` deviates from expected elapsed by more than ~2s. |
+| F11 | Fixed | `onReady` fallback refreshes `startTime` even when the `streamId` already matches. |
+| F12 | Fixed | Server computes and sends the seek `offset` consistently on every `START_MUSIC_STREAM` path; client consumes it for the initial seek instead of deriving from raw `startTime`. |
+| F13 | Fixed — needs runtime verification | A `MUSIC_STREAM_TICK` carrying a newer `streamId` rehydrates client stream state from `room.state.musicStream` (recovers a missed `START_MUSIC_STREAM`). |
+| F14 | Fixed — needs runtime verification | `clampTrackDuration` (5 s – 4 h, non-finite/≤0 → 0 "unknown") applied at both ingestion points (room-queue add, jukebox add). Unknown duration now arms a 10-minute fallback watchdog instead of no watchdog. `youtubeService` has no metadata plumbing (prefetch only), so clamp-to-sane-bounds was used per the audit's fallback direction. |

--- a/server/src/__tests__/djRotation.test.ts
+++ b/server/src/__tests__/djRotation.test.ts
@@ -101,9 +101,32 @@ describe('advanceRotation — F1: rotates the CURRENT DJ, not djQueue[0]', () =>
     expect(room.state.currentDjSessionId).toBe('A')
   })
 
-  it('stops the stream when no DJ has unplayed tracks', () => {
+  // F8: a full cycle through every DJ's playlist must loop, not strand the
+  // rotation in silence until a human presses ▶.
+  it('loops the rotation by resetting played flags when every queued DJ is exhausted (F8)', () => {
     const alice = addPlayer(room, 'A', 'Alice', ['track-a'])
+    const bob = addPlayer(room, 'B', 'Bob', ['track-b'])
     alice.roomQueuePlaylist[0].played = true
+    bob.roomQueuePlaylist[0].played = true
+    addToQueue(room, 'A', 'Alice', 0)
+    addToQueue(room, 'B', 'Bob', 1)
+    room.state.currentDjSessionId = 'A'
+
+    advanceRotation(room)
+
+    // Rotation continues: A rotated to the back, B starts a fresh cycle
+    expect(queueIds(room)).toEqual(['B', 'A'])
+    expect(room.state.currentDjSessionId).toBe('B')
+    expect(room.state.musicStream.status).toBe('playing')
+    expect(room.state.musicStream.currentTitle).toBe('track-b')
+    // Both flags were reset by the loop; marking happens via markTrackAsPlayed
+    // on turn completion, not at playback start — so both are false here
+    expect(bob.roomQueuePlaylist[0].played).toBe(false)
+    expect(alice.roomQueuePlaylist[0].played).toBe(false)
+  })
+
+  it('still stops the stream when queued DJs have no tracks at all (nothing to loop)', () => {
+    addPlayer(room, 'A', 'Alice') // empty playlist — no flags to reset
     addToQueue(room, 'A', 'Alice', 0)
     room.state.currentDjSessionId = 'A'
 

--- a/server/src/__tests__/djRotation.test.ts
+++ b/server/src/__tests__/djRotation.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { RoomState, Player, DJQueueEntry, RoomQueuePlaylistItem } from '@club-mutant/types/RoomState'
+import { advanceRotation } from '../rooms/commands/djHelpers'
+import { DJTurnCompleteCommand } from '../rooms/commands/DJQueueCommand'
+import type { ClubMutant } from '../rooms/ClubMutant'
+
+// djHelpers.playTrackForCurrentDJ prefetches the next DJ's track — stub the
+// network call out (module id resolves to server/src/youtubeService).
+vi.mock('../youtubeService', () => ({
+  prefetchVideo: vi.fn(),
+}))
+
+function makeRoom(): ClubMutant {
+  const room = {
+    state: new RoomState(),
+    broadcast: vi.fn(),
+    notifyNpcMusicStarted: vi.fn(),
+  }
+  return room as unknown as ClubMutant
+}
+
+function addPlayer(room: ClubMutant, sessionId: string, name: string, trackTitles: string[] = []) {
+  const player = new Player()
+  player.name = name
+  for (const title of trackTitles) {
+    const item = new RoomQueuePlaylistItem()
+    item.id = `${sessionId}-${title}`
+    item.title = title
+    item.link = `https://youtu.be/${title}`
+    item.duration = 180
+    player.roomQueuePlaylist.push(item)
+  }
+  room.state.players.set(sessionId, player)
+  return player
+}
+
+function addToQueue(room: ClubMutant, sessionId: string, name: string, slotIndex: number) {
+  const entry = new DJQueueEntry()
+  entry.sessionId = sessionId
+  entry.name = name
+  entry.joinedAtMs = Date.now()
+  entry.queuePosition = room.state.djQueue.length
+  entry.slotIndex = slotIndex
+  room.state.djQueue.push(entry)
+  return entry
+}
+
+function queueIds(room: ClubMutant): string[] {
+  return room.state.djQueue.toArray().map((e) => e.sessionId)
+}
+
+function runTurnComplete(room: ClubMutant, sessionId: string, streamId?: number) {
+  const cmd = new DJTurnCompleteCommand()
+  ;(cmd as any).room = room
+  ;(cmd as any).state = room.state
+  cmd.execute({ client: { sessionId } as any, streamId })
+}
+
+describe('advanceRotation — F1: rotates the CURRENT DJ, not djQueue[0]', () => {
+  let room: ClubMutant
+
+  beforeEach(() => {
+    room = makeRoom()
+  })
+
+  it('moves the entry matching currentDjSessionId to the end when it is not at index 0', () => {
+    addPlayer(room, 'A', 'Alice', ['track-a'])
+    addPlayer(room, 'B', 'Bob', ['track-b'])
+    addPlayer(room, 'C', 'Carol') // no tracks
+    addToQueue(room, 'A', 'Alice', 0)
+    addToQueue(room, 'B', 'Bob', 1)
+    addToQueue(room, 'C', 'Carol', 2)
+
+    // B is current despite sitting at index 1 (join/DJ_PLAY promotion paths do this)
+    room.state.currentDjSessionId = 'B'
+
+    advanceRotation(room)
+
+    // B (the current DJ) rotated to the end — A must NOT be starved
+    expect(queueIds(room)).toEqual(['A', 'C', 'B'])
+    expect(room.state.currentDjSessionId).toBe('A')
+    expect(room.state.musicStream.status).toBe('playing')
+    expect(room.state.musicStream.currentTitle).toBe('track-a')
+    // queuePosition re-numbered contiguously
+    expect(room.state.djQueue.toArray().map((e) => e.queuePosition)).toEqual([0, 1, 2])
+  })
+
+  it('drops a disconnected current DJ instead of re-queueing them', () => {
+    addPlayer(room, 'A', 'Alice', ['track-a'])
+    addToQueue(room, 'A', 'Alice', 0)
+    addToQueue(room, 'B', 'Bob', 1) // entry exists but player left (no players entry)
+    room.state.currentDjSessionId = 'B'
+
+    advanceRotation(room)
+
+    expect(queueIds(room)).toEqual(['A'])
+    expect(room.state.currentDjSessionId).toBe('A')
+  })
+
+  it('stops the stream when no DJ has unplayed tracks', () => {
+    const alice = addPlayer(room, 'A', 'Alice', ['track-a'])
+    alice.roomQueuePlaylist[0].played = true
+    addToQueue(room, 'A', 'Alice', 0)
+    room.state.currentDjSessionId = 'A'
+
+    advanceRotation(room)
+
+    expect(room.state.currentDjSessionId).toBeNull()
+    expect(room.state.musicStream.status).toBe('waiting')
+    expect(room.state.musicStream.currentLink).toBeNull()
+  })
+})
+
+describe('DJTurnCompleteCommand — F4: stale/duplicate completions are rejected', () => {
+  let room: ClubMutant
+
+  beforeEach(() => {
+    room = makeRoom()
+    addPlayer(room, 'A', 'Alice', ['track-a'])
+    addPlayer(room, 'B', 'Bob', ['track-b'])
+    addToQueue(room, 'A', 'Alice', 0)
+    addToQueue(room, 'B', 'Bob', 1)
+    room.state.currentDjSessionId = 'A'
+    room.state.musicStream.status = 'playing'
+    room.state.musicStream.streamId = 5
+    room.state.musicStream.currentTitle = 'track-a'
+  })
+
+  it('ignores a turn-complete carrying a stale streamId', () => {
+    runTurnComplete(room, 'A', 4) // stale — current stream is 5
+
+    expect(room.state.currentDjSessionId).toBe('A')
+    expect(queueIds(room)).toEqual(['A', 'B'])
+    const alice = room.state.players.get('A')!
+    expect(alice.roomQueuePlaylist[0].played).toBe(false)
+  })
+
+  it('processes a turn-complete with the matching streamId', () => {
+    runTurnComplete(room, 'A', 5)
+
+    // A's track marked played, rotation advanced to B
+    expect(room.state.currentDjSessionId).toBe('B')
+    expect(queueIds(room)).toEqual(['B', 'A'])
+    const alice = room.state.players.get('A')!
+    expect(alice.roomQueuePlaylist.some((t) => t.played)).toBe(true)
+    expect(room.state.musicStream.currentTitle).toBe('track-b')
+  })
+
+  it('still accepts a payload without streamId (watchdog/legacy senders)', () => {
+    runTurnComplete(room, 'A', undefined)
+    expect(room.state.currentDjSessionId).toBe('B')
+  })
+
+  it('rejects a turn-complete from a non-current DJ even with matching streamId', () => {
+    runTurnComplete(room, 'B', 5)
+    expect(room.state.currentDjSessionId).toBe('A')
+    expect(queueIds(room)).toEqual(['A', 'B'])
+  })
+})

--- a/server/src/__tests__/djRotation.test.ts
+++ b/server/src/__tests__/djRotation.test.ts
@@ -15,6 +15,10 @@ function makeRoom(): ClubMutant {
     state: new RoomState(),
     broadcast: vi.fn(),
     notifyNpcMusicStarted: vi.fn(),
+    // F2: the helpers own the watchdog lifecycle — stubbed here since the
+    // real timers live on the Colyseus room, not under rotation test.
+    clearTrackWatchdog: vi.fn(),
+    startWatchdogIfPlaying: vi.fn(),
   }
   return room as unknown as ClubMutant
 }

--- a/server/src/__tests__/djRotation.test.ts
+++ b/server/src/__tests__/djRotation.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { RoomState, Player, DJQueueEntry, RoomQueuePlaylistItem } from '@club-mutant/types/RoomState'
-import { advanceRotation } from '../rooms/commands/djHelpers'
+import { advanceRotation, markTrackAsPlayed, removeDJFromQueue } from '../rooms/commands/djHelpers'
 import { DJTurnCompleteCommand } from '../rooms/commands/DJQueueCommand'
 import type { ClubMutant } from '../rooms/ClubMutant'
 
@@ -159,5 +159,126 @@ describe('DJTurnCompleteCommand — F4: stale/duplicate completions are rejected
     runTurnComplete(room, 'B', 5)
     expect(room.state.currentDjSessionId).toBe('A')
     expect(queueIds(room)).toEqual(['A', 'B'])
+  })
+})
+
+describe('removeDJFromQueue — F5: leave-promotion skips exhausted DJs', () => {
+  let room: ClubMutant
+
+  beforeEach(() => {
+    room = makeRoom()
+  })
+
+  it('promotes the next DJ with UNPLAYED tracks, not blindly djQueue[0]', () => {
+    addPlayer(room, 'A', 'Alice', ['track-a'])
+    const bob = addPlayer(room, 'B', 'Bob', ['track-b'])
+    bob.roomQueuePlaylist[0].played = true // B exhausted their playlist
+    addPlayer(room, 'C', 'Carol', ['track-c'])
+    addToQueue(room, 'A', 'Alice', 0)
+    addToQueue(room, 'B', 'Bob', 1)
+    addToQueue(room, 'C', 'Carol', 2)
+    room.state.currentDjSessionId = 'A'
+    room.state.musicStream.status = 'playing'
+
+    removeDJFromQueue(room, 'A')
+
+    // C (first with unplayed tracks) is current and playing; B was skipped
+    expect(room.state.currentDjSessionId).toBe('C')
+    expect(queueIds(room)).toEqual(['C', 'B'])
+    expect(room.state.musicStream.status).toBe('playing')
+    expect(room.state.musicStream.currentTitle).toBe('track-c')
+    // B's played flags untouched — they were skipped, not reset
+    expect(bob.roomQueuePlaylist[0].played).toBe(true)
+  })
+
+  it('loop-resets an exhausted playlist when nobody has unplayed tracks', () => {
+    addPlayer(room, 'A', 'Alice', ['track-a'])
+    const bob = addPlayer(room, 'B', 'Bob', ['track-b'])
+    bob.roomQueuePlaylist[0].played = true
+    addToQueue(room, 'A', 'Alice', 0)
+    addToQueue(room, 'B', 'Bob', 1)
+    room.state.currentDjSessionId = 'A'
+    room.state.musicStream.status = 'playing'
+
+    removeDJFromQueue(room, 'A')
+
+    // B promoted; their fully-played playlist was reset and playback resumed
+    // instead of stalling silently (the old length>0 check no-opped here)
+    expect(room.state.currentDjSessionId).toBe('B')
+    expect(room.state.musicStream.status).toBe('playing')
+    expect(room.state.musicStream.currentTitle).toBe('track-b')
+  })
+
+  it('promotes a trackless DJ as waiting current without crashing', () => {
+    addPlayer(room, 'A', 'Alice', ['track-a'])
+    addPlayer(room, 'B', 'Bob') // no tracks at all
+    addToQueue(room, 'A', 'Alice', 0)
+    addToQueue(room, 'B', 'Bob', 1)
+    room.state.currentDjSessionId = 'A'
+    room.state.musicStream.status = 'playing'
+
+    removeDJFromQueue(room, 'A')
+
+    expect(room.state.currentDjSessionId).toBe('B')
+    expect(room.state.musicStream.status).toBe('waiting')
+    expect(room.state.musicStream.currentLink).toBeNull()
+  })
+})
+
+describe('markTrackAsPlayed — F7: marks the track that actually played', () => {
+  let room: ClubMutant
+
+  beforeEach(() => {
+    room = makeRoom()
+  })
+
+  it('marks the track matching the given id even at index > 0', () => {
+    const alice = addPlayer(room, 'A', 'Alice', ['old-track', 'actual-track'])
+    alice.roomQueuePlaylist[0].played = true // played track reordered to index 0
+
+    markTrackAsPlayed(alice, 'A-actual-track')
+
+    // The actually-playing track (index 1) got marked and moved to the bottom
+    const titles = alice.roomQueuePlaylist.map((t) => t.title)
+    expect(titles).toEqual(['old-track', 'actual-track'])
+    const actual = alice.roomQueuePlaylist.find((t) => t.id === 'A-actual-track')!
+    expect(actual.played).toBe(true)
+  })
+
+  it('marks nothing when the id is no longer in the playlist', () => {
+    const alice = addPlayer(room, 'A', 'Alice', ['bystander'])
+
+    markTrackAsPlayed(alice, 'A-gone-track')
+
+    expect(alice.roomQueuePlaylist[0].played).toBe(false)
+    expect(alice.roomQueuePlaylist.length).toBe(1)
+  })
+
+  it('falls back to index 0 when no id is provided (legacy callers)', () => {
+    const alice = addPlayer(room, 'A', 'Alice', ['first', 'second'])
+
+    markTrackAsPlayed(alice, null)
+
+    const first = alice.roomQueuePlaylist.find((t) => t.id === 'A-first')!
+    expect(first.played).toBe(true)
+    expect(alice.roomQueuePlaylist[alice.roomQueuePlaylist.length - 1].id).toBe('A-first')
+  })
+
+  it('turn-complete marks the currentTrackId track, not index 0', () => {
+    const alice = addPlayer(room, 'A', 'Alice', ['old-track', 'actual-track'])
+    alice.roomQueuePlaylist[0].played = true
+    addPlayer(room, 'B', 'Bob', ['track-b'])
+    addToQueue(room, 'A', 'Alice', 0)
+    addToQueue(room, 'B', 'Bob', 1)
+    room.state.currentDjSessionId = 'A'
+    room.state.musicStream.status = 'playing'
+    room.state.musicStream.streamId = 7
+    room.state.musicStream.currentTrackId = 'A-actual-track'
+
+    runTurnComplete(room, 'A', 7)
+
+    const actual = alice.roomQueuePlaylist.find((t) => t.id === 'A-actual-track')!
+    expect(actual.played).toBe(true)
+    expect(room.state.currentDjSessionId).toBe('B')
   })
 })

--- a/server/src/data/npc-playlists/default.json
+++ b/server/src/data/npc-playlists/default.json
@@ -1,0 +1,78 @@
+{
+  "id": "default",
+  "name": "House Rotation",
+  "tracks": [
+    {
+      "id": "dQw4w9WgXcQ",
+      "title": "Rick Astley - Never Gonna Give You Up",
+      "link": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "duration": 213
+    },
+    {
+      "id": "9bZkp7q19f0",
+      "title": "PSY - Gangnam Style",
+      "link": "https://www.youtube.com/watch?v=9bZkp7q19f0",
+      "duration": 252
+    },
+    {
+      "id": "fJ9rUzIMcZQ",
+      "title": "Queen - Bohemian Rhapsody",
+      "link": "https://www.youtube.com/watch?v=fJ9rUzIMcZQ",
+      "duration": 359
+    },
+    {
+      "id": "FTQbiNvZqaY",
+      "title": "Toto - Africa",
+      "link": "https://www.youtube.com/watch?v=FTQbiNvZqaY",
+      "duration": 271
+    },
+    {
+      "id": "djV11Xbc914",
+      "title": "a-ha - Take On Me",
+      "link": "https://www.youtube.com/watch?v=djV11Xbc914",
+      "duration": 244
+    },
+    {
+      "id": "FGBhQbmPwH8",
+      "title": "Daft Punk - One More Time",
+      "link": "https://www.youtube.com/watch?v=FGBhQbmPwH8",
+      "duration": 321
+    },
+    {
+      "id": "Gs069dndIYk",
+      "title": "Earth, Wind & Fire - September",
+      "link": "https://www.youtube.com/watch?v=Gs069dndIYk",
+      "duration": 215
+    },
+    {
+      "id": "y6120QOlsfU",
+      "title": "Darude - Sandstorm",
+      "link": "https://www.youtube.com/watch?v=y6120QOlsfU",
+      "duration": 232
+    },
+    {
+      "id": "Zi_XLOBDo_Y",
+      "title": "Michael Jackson - Billie Jean",
+      "link": "https://www.youtube.com/watch?v=Zi_XLOBDo_Y",
+      "duration": 296
+    },
+    {
+      "id": "hTWKbfoikeg",
+      "title": "Nirvana - Smells Like Teen Spirit",
+      "link": "https://www.youtube.com/watch?v=hTWKbfoikeg",
+      "duration": 278
+    },
+    {
+      "id": "4NRXx6U8ABQ",
+      "title": "The Weeknd - Blinding Lights",
+      "link": "https://www.youtube.com/watch?v=4NRXx6U8ABQ",
+      "duration": 263
+    },
+    {
+      "id": "OPf0YbXqDm0",
+      "title": "Mark Ronson - Uptown Funk ft. Bruno Mars",
+      "link": "https://www.youtube.com/watch?v=OPf0YbXqDm0",
+      "duration": 270
+    }
+  ]
+}

--- a/server/src/rooms/ClubMutant.ts
+++ b/server/src/rooms/ClubMutant.ts
@@ -52,6 +52,11 @@ import { NpcDjManager, parseNpcDjLobbyEnv } from './NpcDjManager'
 
 const LOG_ENABLED = process.env.NODE_ENV !== 'production'
 
+// F14: fallback watchdog window for tracks whose duration is unknown (0).
+// Long enough to never cut a legitimate track short in practice, short
+// enough that a stalled rotation always recovers without human input.
+const UNKNOWN_DURATION_WATCHDOG_MS = 10 * 60 * 1000
+
 // ── NPC Constants ──
 const NPC_SESSION_ID = 'npc_lily'
 const NPC_NAME = 'Lily'
@@ -187,9 +192,18 @@ export class ClubMutant extends Room {
   startWatchdogIfPlaying() {
     const ms = this.state.musicStream
 
-    if (ms.status === 'playing' && ms.currentLink && ms.duration > 0) {
+    if (ms.status !== 'playing' || !ms.currentLink) return
+
+    if (ms.duration > 0) {
       const remainingMs = ms.startTime + ms.duration * 1000 - Date.now()
       this.startTrackWatchdog(Math.max(remainingMs, 0))
+    } else {
+      // F14: unknown duration (client sent 0 / unparseable) used to mean NO
+      // watchdog at all — combined with a missing turn-complete that was a
+      // permanent stall. Arm a conservative fallback so the rotation always
+      // has a backstop, measured from the stream's startTime.
+      const elapsedMs = Math.max(Date.now() - ms.startTime, 0)
+      this.startTrackWatchdog(Math.max(UNKNOWN_DURATION_WATCHDOG_MS - elapsedMs, 0))
     }
   }
 

--- a/server/src/rooms/ClubMutant.ts
+++ b/server/src/rooms/ClubMutant.ts
@@ -233,7 +233,11 @@ export class ClubMutant extends Room {
     musicStream.startTime = Date.now()
     musicStream.duration = 0
 
-    this.broadcast(Message.START_MUSIC_STREAM, { musicStream, offset: 0 })
+    // F12: keep the offset field truthful on every send path
+    this.broadcast(Message.START_MUSIC_STREAM, {
+      musicStream,
+      offset: (Date.now() - musicStream.startTime) / 1000,
+    })
   }
 
   private startMusicStreamTickIfNeeded() {

--- a/server/src/rooms/ClubMutant.ts
+++ b/server/src/rooms/ClubMutant.ts
@@ -202,6 +202,7 @@ export class ClubMutant extends Room {
     musicStream.status = 'waiting'
     musicStream.currentLink = null
     musicStream.currentTitle = null
+    musicStream.currentTrackId = null
     musicStream.currentVisualUrl = null
     musicStream.currentTrackMessage = null
     musicStream.startTime = Date.now()

--- a/server/src/rooms/ClubMutant.ts
+++ b/server/src/rooms/ClubMutant.ts
@@ -48,6 +48,7 @@ import {
 
 import ChatMessageUpdateCommand from './commands/ChatMessageUpdateCommand'
 import PunchPlayerCommand from './commands/PunchPlayerCommand'
+import { NpcDjManager, parseNpcDjLobbyEnv } from './NpcDjManager'
 
 const LOG_ENABLED = process.env.NODE_ENV !== 'production'
 
@@ -90,6 +91,9 @@ export class ClubMutant extends Room {
   private trackWatchdogTimerId: NodeJS.Timeout | null = null
 
   private ambientPublicVideoId = '5-gDL5G-VQQ' //'5-gDL5G-VQQ'
+
+  // ── NPC automaton DJ (Phase 1) ──
+  private npcDjManager: NpcDjManager | null = null
 
   // ── NPC state ──
   private npcUpdateIntervalId: NodeJS.Timeout | null = null
@@ -162,7 +166,9 @@ export class ClubMutant extends Room {
     }, timeoutMs)
   }
 
-  private clearTrackWatchdog() {
+  // Public: the NPC DJ manager clears/re-arms the watchdog around its own
+  // track-advance timer (its timer is the sole authority for NPC tracks).
+  clearTrackWatchdog() {
     if (this.trackWatchdogTimerId) {
       clearTimeout(this.trackWatchdogTimerId)
       this.trackWatchdogTimerId = null
@@ -170,7 +176,7 @@ export class ClubMutant extends Room {
   }
 
   /** Helper: start watchdog if a track is currently playing with a known duration. */
-  private startWatchdogIfPlaying() {
+  startWatchdogIfPlaying() {
     const ms = this.state.musicStream
 
     if (ms.status === 'playing' && ms.currentLink && ms.duration > 0) {
@@ -241,7 +247,9 @@ export class ClubMutant extends Room {
     this.musicStreamTickIntervalId = null
   }
 
-  private stopAmbientIfNeeded() {
+  // Public: also called by the NPC DJ manager when it takes over the booth
+  // (mirrors what the human booth-connect path does).
+  stopAmbientIfNeeded() {
     const musicStream = this.state.musicStream
     if (!musicStream.isAmbient) return
 
@@ -789,6 +797,19 @@ export class ClubMutant extends Room {
     if (this.musicMode === 'jukebox') {
       this.spawnNpc()
       this.startNpcHeartbeat()
+    }
+
+    // Spawn NPC automaton DJ for djqueue rooms (Phase 1: config at room
+    // creation, or NPC_DJ_LOBBY env for the public lobby)
+    if (this.musicMode === 'djqueue') {
+      const npcDjConfig =
+        options.npcDj ?? (this.isPublic ? parseNpcDjLobbyEnv(process.env.NPC_DJ_LOBBY) : null)
+      if (npcDjConfig) {
+        const manager = new NpcDjManager(this, npcDjConfig)
+        if (manager.spawn()) {
+          this.npcDjManager = manager
+        }
+      }
     }
 
     this.onMessage(Message.TIME_SYNC_REQUEST, (client, message: { clientSentAtMs?: unknown }) => {
@@ -1354,6 +1375,8 @@ export class ClubMutant extends Room {
 
     this.stopNpcHeartbeat()
     this.cleanupNpc()
+    this.npcDjManager?.dispose()
+    this.npcDjManager = null
     this.clearTrackWatchdog()
     this.stopMusicStreamTickIfNeeded()
     this.dispatcher.stop()

--- a/server/src/rooms/ClubMutant.ts
+++ b/server/src/rooms/ClubMutant.ts
@@ -154,6 +154,8 @@ export class ClubMutant extends Room {
           client: { sessionId: '' } as Client,
           streamId: ms.streamId,
         })
+        // F2: watchdog-driven jukebox advance must protect the next track too
+        this.startWatchdogIfPlaying()
       } else {
         const djId = this.state.currentDjSessionId
         if (!djId) return
@@ -176,16 +178,25 @@ export class ClubMutant extends Room {
     }
   }
 
-  /** Helper: start watchdog if a track is currently playing with a known duration. */
+  /**
+   * Helper: (re-)arm the watchdog if a track is currently playing with a known
+   * duration. Uses the REMAINING time (startTime + duration - now) rather than
+   * the full duration so mid-track re-arms don't push the deadline out (F3) —
+   * startTrackWatchdog still adds its own grace buffer on top.
+   */
   startWatchdogIfPlaying() {
     const ms = this.state.musicStream
 
     if (ms.status === 'playing' && ms.currentLink && ms.duration > 0) {
-      this.startTrackWatchdog(ms.duration * 1000)
+      const remainingMs = ms.startTime + ms.duration * 1000 - Date.now()
+      this.startTrackWatchdog(Math.max(remainingMs, 0))
     }
   }
 
   private setStoppedMusicStream() {
+    // F2: every stop path kills the watchdog so it can't fire for a dead stream
+    this.clearTrackWatchdog()
+
     const musicStream = this.state.musicStream
 
     musicStream.status = 'waiting'
@@ -1041,37 +1052,33 @@ export class ClubMutant extends Room {
         })
       })
 
+      // F2: no watchdog wrappers here — the DJ command/helper layer owns the
+      // watchdog lifecycle (playTrackForCurrentDJ arms, every stop path clears).
+      // This also means a REJECTED command (e.g. stale DJ_TURN_COMPLETE, F4)
+      // leaves the running track's watchdog untouched instead of resetting it.
       this.onMessage(Message.DJ_QUEUE_LEAVE, (client) => {
         if (this.throttle(client, Message.DJ_QUEUE_LEAVE, 2000)) return
-        this.clearTrackWatchdog()
         this.dispatcher.dispatch(new DJQueueLeaveCommand(), { client })
-        this.startWatchdogIfPlaying()
       })
 
       this.onMessage(Message.DJ_PLAY, (client) => {
         this.dispatcher.dispatch(new DJPlayCommand(), { client })
-        this.startWatchdogIfPlaying()
       })
 
       this.onMessage(Message.DJ_STOP, (client) => {
-        this.clearTrackWatchdog()
         this.dispatcher.dispatch(new DJStopCommand(), { client })
       })
 
       this.onMessage(Message.DJ_SKIP_TURN, (client) => {
-        this.clearTrackWatchdog()
         this.dispatcher.dispatch(new DJSkipTurnCommand(), { client })
-        this.startWatchdogIfPlaying()
       })
 
       // Carries streamId (F4) — server deduplicates stale/duplicate completions.
       this.onMessage(Message.DJ_TURN_COMPLETE, (client, message) => {
-        this.clearTrackWatchdog()
         this.dispatcher.dispatch(new DJTurnCompleteCommand(), {
           client,
           streamId: message?.streamId,
         })
-        this.startWatchdogIfPlaying()
       })
 
       // Room Queue Playlist Management (per-player, djqueue mode only)

--- a/server/src/rooms/ClubMutant.ts
+++ b/server/src/rooms/ClubMutant.ts
@@ -161,6 +161,7 @@ export class ClubMutant extends Room {
         console.log('[Watchdog] Track duration exceeded for DJ %s, auto-advancing', djId)
         this.dispatcher.dispatch(new DJTurnCompleteCommand(), {
           client: { sessionId: djId } as Client,
+          streamId: ms.streamId,
         })
       }
     }, timeoutMs)
@@ -1063,9 +1064,13 @@ export class ClubMutant extends Room {
         this.startWatchdogIfPlaying()
       })
 
-      this.onMessage(Message.DJ_TURN_COMPLETE, (client) => {
+      // Carries streamId (F4) — server deduplicates stale/duplicate completions.
+      this.onMessage(Message.DJ_TURN_COMPLETE, (client, message) => {
         this.clearTrackWatchdog()
-        this.dispatcher.dispatch(new DJTurnCompleteCommand(), { client })
+        this.dispatcher.dispatch(new DJTurnCompleteCommand(), {
+          client,
+          streamId: message?.streamId,
+        })
         this.startWatchdogIfPlaying()
       })
 

--- a/server/src/rooms/NpcDjManager.ts
+++ b/server/src/rooms/NpcDjManager.ts
@@ -1,0 +1,445 @@
+// NPC automaton DJ (Phase 1) — a headless server-side Player that occupies a
+// DJ booth slot and plays a curated playlist.
+// See docs/plans/2026-07-05-npc-dj-design.md + docs/plans/2026-07-05-npc-dj-implementation.md
+//
+// CRITICAL: the NPC has NO Colyseus Client. It must never flow through Command
+// objects that call client.send(...) — it only uses the client-free helpers in
+// commands/djHelpers.ts.
+//
+// Timing authority: the manager's own track timer is the SOLE authority for
+// advancing NPC tracks. The room track watchdog is not a reliable backstop
+// (it never re-arms after auto-advancing and isn't cleared on leave — see
+// docs/plans/2026-07-05-dj-queue-audit.md), so the manager defensively clears
+// it whenever it arms its own timer or advances the rotation.
+
+import { ChatMessage, Player } from '@club-mutant/types/RoomState'
+import { RoomQueuePlaylistItem } from '@club-mutant/types/RoomState'
+import { Message } from '@club-mutant/types/Messages'
+import type { INpcDjConfig } from '@club-mutant/types/Rooms'
+import { TEXTURE_IDS, sanitizeTextureId } from '@club-mutant/types/AnimationCodec'
+
+import type { ClubMutant } from './ClubMutant'
+import {
+  DJ_SLOT_SERVER_X,
+  advanceRotation,
+  hasUnplayedTracks,
+  joinDjQueue,
+  markTrackAsPlayed,
+  playTrackForCurrentDJ,
+  removeDJFromQueue,
+} from './commands/djHelpers'
+import { NpcPlaylist, loadNpcPlaylist } from './npcPlaylists'
+
+// Reserved session ID prefix — no real Colyseus sessionId can collide with it,
+// and guards (punch targeting, BOT badge) key off it.
+export const NPC_DJ_SESSION_PREFIX = 'npc-dj:'
+
+const WATCH_INTERVAL_MS = 1000
+
+// Where the NPC stands when not behind the booth (fallback mode, waiting).
+const NPC_DJ_STANDBY_X = 220
+const NPC_DJ_STANDBY_Y = 500
+
+const NPC_DJ_NAME_POOL = ['DJ Automaton', 'Unit-33', 'The Resident', 'Vinyl Golem', 'MC Circuit']
+
+const TRACK_START_TEMPLATES = [
+  '🎧 now spinning: {title}',
+  'up next on the decks — {title}',
+  '{title}. enjoy.',
+]
+
+const FALLBACK_JOIN_MESSAGE = "taking over while the booth's empty."
+
+/**
+ * Parse the NPC_DJ_LOBBY env var ("<mode>" or "<mode>:<playlistId>",
+ * e.g. "fallback:default"). Returns null when unset or invalid.
+ */
+export function parseNpcDjLobbyEnv(raw: string | undefined): INpcDjConfig | null {
+  if (!raw) return null
+  const [mode, playlistId] = raw.split(':').map((part) => part.trim())
+  if (mode !== 'fallback' && mode !== 'rotation') {
+    console.warn('[NpcDj] Ignoring NPC_DJ_LOBBY with invalid mode:', raw)
+    return null
+  }
+  return { mode, playlistId: playlistId || undefined }
+}
+
+export class NpcDjManager {
+  readonly sessionId: string
+
+  private room: ClubMutant
+  private config: INpcDjConfig
+  private name: string
+  private playlist: NpcPlaylist | null = null
+
+  private watchIntervalId: NodeJS.Timeout | null = null
+  private trackTimerId: NodeJS.Timeout | null = null
+  private trackTimerStreamId = -1
+  private lastAnnouncedStreamId = -1
+  private leaveAfterTrack = false
+  private disposed = false
+
+  constructor(room: ClubMutant, config: INpcDjConfig) {
+    this.room = room
+    this.config = config
+    this.sessionId = `${NPC_DJ_SESSION_PREFIX}${room.roomId}`
+    this.name =
+      config.name?.trim() ||
+      NPC_DJ_NAME_POOL[Math.floor(Math.random() * NPC_DJ_NAME_POOL.length)]
+  }
+
+  /**
+   * Load the playlist and spawn the NPC player entity.
+   * Returns false (and does NOT spawn) when the playlist is missing/invalid.
+   */
+  spawn(): boolean {
+    const playlistId = this.config.playlistId ?? 'default'
+    const playlist = loadNpcPlaylist(playlistId)
+    if (!playlist) {
+      console.error('[NpcDj] Refusing to spawn — playlist missing or invalid:', playlistId)
+      return false
+    }
+    this.playlist = playlist
+
+    const npc = new Player()
+    npc.name = this.name
+    npc.isNpc = true
+    npc.textureId =
+      typeof this.config.textureId === 'number'
+        ? sanitizeTextureId(this.config.textureId)
+        : this.randomTextureId()
+    npc.x = NPC_DJ_STANDBY_X
+    npc.y = NPC_DJ_STANDBY_Y
+    npc.readyToConnect = true
+    npc.connected = true
+    npc.roomQueuePlaylist = this.buildQueuePlaylist()
+    this.room.state.players.set(this.sessionId, npc)
+
+    console.log(
+      '[NpcDj] Spawned:',
+      this.name,
+      `mode=${this.config.mode}`,
+      `playlist=${playlist.name} (${playlist.tracks.length} tracks)`
+    )
+
+    // Join/play immediately (rotation always joins; fallback joins while no
+    // humans are queued), then keep watching.
+    this.tick()
+    this.watchIntervalId = setInterval(() => this.tick(), WATCH_INTERVAL_MS)
+    return true
+  }
+
+  /** Tear down timers and remove the NPC from queue/booth/state (room dispose). */
+  dispose() {
+    if (this.disposed) return
+    this.disposed = true
+
+    if (this.watchIntervalId !== null) {
+      clearInterval(this.watchIntervalId)
+      this.watchIntervalId = null
+    }
+    this.clearTrackTimer()
+
+    if (this.room.state.djQueue.some((e) => e.sessionId === this.sessionId)) {
+      removeDJFromQueue(this.room, this.sessionId)
+    }
+    this.disconnectBooth()
+    this.room.state.players.delete(this.sessionId)
+    console.log('[NpcDj] Disposed:', this.sessionId)
+  }
+
+  // ── Watcher loop ───────────────────────────────────────────────────────────
+
+  private tick() {
+    if (this.disposed) return
+    const state = this.room.state
+    if (!state.players.has(this.sessionId)) return
+
+    const musicStream = state.musicStream
+
+    // Our advance timer is only valid for the exact stream it was armed for.
+    if (
+      this.trackTimerId !== null &&
+      (musicStream.status !== 'playing' || musicStream.streamId !== this.trackTimerStreamId)
+    ) {
+      this.clearTrackTimer()
+    }
+
+    const npcQueued = state.djQueue.some((e) => e.sessionId === this.sessionId)
+    const humanQueued = state.djQueue.some(
+      (e) => !e.sessionId.startsWith(NPC_DJ_SESSION_PREFIX)
+    )
+    const npcPlaying =
+      state.currentDjSessionId === this.sessionId &&
+      musicStream.status === 'playing' &&
+      !musicStream.isAmbient
+
+    if (this.config.mode === 'fallback') {
+      if (humanQueued) {
+        if (npcQueued) {
+          if (npcPlaying) {
+            // Finish the current track first; hand over on track end.
+            this.leaveAfterTrack = true
+          } else {
+            // Not mid-track — hand over immediately.
+            this.leaveQueue()
+            return
+          }
+        }
+      } else {
+        this.leaveAfterTrack = false
+        if (!npcQueued) this.joinQueue()
+      }
+    } else if (!npcQueued) {
+      // Rotation mode: permanent queue member — re-join whenever we fall out.
+      this.joinQueue()
+    }
+
+    // Start playback when we're the current DJ and nothing is playing.
+    const shouldPlay =
+      state.currentDjSessionId === this.sessionId &&
+      musicStream.status === 'waiting' &&
+      state.djQueue.some((e) => e.sessionId === this.sessionId) &&
+      !(this.config.mode === 'fallback' && humanQueued)
+
+    if (shouldPlay) {
+      this.startTrack()
+      return
+    }
+
+    // An NPC track can also start outside our control (e.g. a human's
+    // turn-complete promotes us via advanceRotation, which auto-plays).
+    // Adopt it: arm our timer (and announce) for the running stream.
+    if (npcPlaying && this.trackTimerId === null) {
+      this.armTrackTimer()
+    }
+  }
+
+  // ── Queue membership ───────────────────────────────────────────────────────
+
+  private joinQueue(): boolean {
+    const npc = this.room.state.players.get(this.sessionId)
+    if (!npc) return false
+
+    // Reset played flags BEFORE joining so the first playTrackForCurrentDJ
+    // call can't hit its silent no-op (no unplayed tracks → room goes quiet).
+    this.ensureUnplayedTracks(npc)
+
+    const slot = this.findFreeSlot()
+    if (slot === null) return false // queue/slots full — tick retries later
+
+    if (!joinDjQueue(this.room, this.sessionId, this.name, slot)) return false
+
+    // Occupy a booth seat so ambient playback won't hijack the stream while
+    // the NPC is DJing (startAmbientIfNeeded checks booth occupancy).
+    this.connectBooth()
+    this.room.stopAmbientIfNeeded()
+
+    if (this.config.mode === 'fallback') {
+      this.announce(FALLBACK_JOIN_MESSAGE)
+    }
+    return true
+  }
+
+  private leaveQueue() {
+    this.leaveAfterTrack = false
+    this.clearTrackTimer()
+    // removeDJFromQueue may stop our stream and auto-start the next DJ's
+    // track — clear any watchdog armed for the old stream first.
+    this.room.clearTrackWatchdog()
+    removeDJFromQueue(this.room, this.sessionId)
+    this.disconnectBooth()
+    this.moveToStandby()
+    // Match message-handler behavior: re-arm for the promoted DJ's track.
+    this.room.startWatchdogIfPlaying()
+  }
+
+  private findFreeSlot(): number | null {
+    for (let slot = 0; slot < DJ_SLOT_SERVER_X.length; slot++) {
+      if (!this.room.state.djQueue.some((e) => e.slotIndex === slot)) return slot
+    }
+    return null
+  }
+
+  private connectBooth() {
+    const booth = this.room.state.musicBooths[0]
+    if (!booth) return
+    if (booth.connectedUsers.some((id) => id === this.sessionId)) return
+    const emptyIndex = booth.connectedUsers.findIndex((id) => id === '')
+    if (emptyIndex < 0) return
+    booth.connectedUsers.splice(emptyIndex, 1, this.sessionId)
+  }
+
+  private disconnectBooth() {
+    const booth = this.room.state.musicBooths[0]
+    if (!booth) return
+    const index = booth.connectedUsers.findIndex((id) => id === this.sessionId)
+    if (index >= 0) booth.connectedUsers.splice(index, 1, '')
+  }
+
+  private moveToStandby() {
+    const npc = this.room.state.players.get(this.sessionId)
+    if (!npc) return
+    npc.x = NPC_DJ_STANDBY_X
+    npc.y = NPC_DJ_STANDBY_Y
+  }
+
+  // ── Playback ───────────────────────────────────────────────────────────────
+
+  private startTrack() {
+    const npc = this.room.state.players.get(this.sessionId)
+    if (!npc) return
+
+    // Loop behavior: reset + reshuffle when the playlist is exhausted, BEFORE
+    // playTrackForCurrentDJ (which silently no-ops without unplayed tracks).
+    this.ensureUnplayedTracks(npc)
+
+    playTrackForCurrentDJ(this.room)
+
+    if (this.room.state.musicStream.status === 'playing') {
+      this.armTrackTimer()
+    } else {
+      console.warn('[NpcDj] startTrack: playTrackForCurrentDJ did not start playback')
+    }
+  }
+
+  /**
+   * Arm the manager's track-advance timer for the currently playing NPC
+   * stream, clearing the room watchdog (we are the sole timing authority for
+   * NPC tracks). Announces the track once per streamId.
+   */
+  private armTrackTimer() {
+    const musicStream = this.room.state.musicStream
+    if (musicStream.status !== 'playing' || !musicStream.currentLink) return
+    if (musicStream.currentDj?.sessionId !== this.sessionId) return
+
+    this.clearTrackTimer()
+    // The watchdog would dispatch DJTurnCompleteCommand with a fake Client at
+    // duration+grace — clear it while our timer owns this stream.
+    this.room.clearTrackWatchdog()
+
+    const streamId = musicStream.streamId
+    const remainingMs = Math.max(
+      0,
+      musicStream.startTime + musicStream.duration * 1000 - Date.now()
+    )
+    this.trackTimerStreamId = streamId
+    this.trackTimerId = setTimeout(() => this.onTrackComplete(streamId), remainingMs)
+
+    if (this.lastAnnouncedStreamId !== streamId) {
+      this.lastAnnouncedStreamId = streamId
+      this.announceTrack(musicStream.currentTitle ?? '')
+    }
+  }
+
+  private clearTrackTimer() {
+    if (this.trackTimerId !== null) {
+      clearTimeout(this.trackTimerId)
+      this.trackTimerId = null
+    }
+    this.trackTimerStreamId = -1
+  }
+
+  private onTrackComplete(streamId: number) {
+    this.trackTimerId = null
+    this.trackTimerStreamId = -1
+    if (this.disposed) return
+
+    const state = this.room.state
+    const musicStream = state.musicStream
+
+    // Stale timer — a different stream started or playback stopped meanwhile.
+    if (musicStream.status !== 'playing' || musicStream.streamId !== streamId) return
+    if (state.currentDjSessionId !== this.sessionId) return
+
+    // Defensive: the watchdog isn't reliably cleared elsewhere — clear it
+    // before advancing so it can't double-advance behind us.
+    this.room.clearTrackWatchdog()
+
+    const npc = state.players.get(this.sessionId)
+    if (npc) markTrackAsPlayed(npc)
+
+    if (this.config.mode === 'fallback' && this.leaveAfterTrack) {
+      console.log('[NpcDj] Track finished with humans waiting — leaving the queue')
+      this.leaveQueue()
+      return
+    }
+
+    // Reset played flags BEFORE advanceRotation — it may promote us again
+    // (solo rotation) and immediately call playTrackForCurrentDJ.
+    if (npc) this.ensureUnplayedTracks(npc)
+
+    // advanceRotation assumes djQueue[0] is the current DJ. If the queue was
+    // reordered under us, hand over via remove(+rejoin) instead.
+    if (state.djQueue.length > 0 && state.djQueue[0].sessionId === this.sessionId) {
+      advanceRotation(this.room)
+    } else {
+      console.warn('[NpcDj] Queue reordered under NPC — remove+rejoin instead of advanceRotation')
+      removeDJFromQueue(this.room, this.sessionId)
+      this.disconnectBooth()
+      if (this.config.mode === 'rotation') this.joinQueue()
+    }
+
+    // Match message-handler behavior: arm the watchdog for whatever track just
+    // started. If it's ours again, the next tick's armTrackTimer reclaims it.
+    this.room.startWatchdogIfPlaying()
+  }
+
+  // ── Playlist ───────────────────────────────────────────────────────────────
+
+  /** Rebuild (reset played flags + reshuffle) when the playlist is exhausted. */
+  private ensureUnplayedTracks(npc: Player) {
+    if (npc.roomQueuePlaylist.length > 0 && hasUnplayedTracks(npc)) return
+    console.log('[NpcDj] Playlist exhausted — resetting played flags and reshuffling')
+    npc.roomQueuePlaylist = this.buildQueuePlaylist()
+  }
+
+  private buildQueuePlaylist(): RoomQueuePlaylistItem[] {
+    const tracks = [...(this.playlist?.tracks ?? [])]
+    // Fisher–Yates shuffle
+    for (let i = tracks.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1))
+      ;[tracks[i], tracks[j]] = [tracks[j], tracks[i]]
+    }
+    return tracks.map((track) => {
+      const item = new RoomQueuePlaylistItem()
+      item.id = track.id
+      item.title = track.title
+      item.link = track.link
+      item.duration = track.duration
+      item.addedAtMs = Date.now()
+      item.played = false
+      return item
+    })
+  }
+
+  // ── Chat announcements ─────────────────────────────────────────────────────
+
+  // Same path as ClubMutant.broadcastNpcMessage: store in the chatMessages
+  // schema for late joiners + broadcast ADD_CHAT_MESSAGE to everyone.
+  private announce(content: string) {
+    const chatMessages = this.room.state.chatMessages
+    if (chatMessages.length >= 25) chatMessages.shift()
+    const msg = new ChatMessage()
+    msg.author = this.name
+    msg.content = content
+    chatMessages.push(msg)
+
+    this.room.broadcast(Message.ADD_CHAT_MESSAGE, {
+      clientId: this.sessionId,
+      content,
+    })
+  }
+
+  private announceTrack(title: string) {
+    if (!title) return
+    const template =
+      TRACK_START_TEMPLATES[Math.floor(Math.random() * TRACK_START_TEMPLATES.length)]
+    this.announce(template.replace('{title}', title))
+  }
+
+  private randomTextureId(): number {
+    const ids = Object.values(TEXTURE_IDS) as number[]
+    return ids[Math.floor(Math.random() * ids.length)]
+  }
+}

--- a/server/src/rooms/NpcDjManager.ts
+++ b/server/src/rooms/NpcDjManager.ts
@@ -244,14 +244,12 @@ export class NpcDjManager {
   private leaveQueue() {
     this.leaveAfterTrack = false
     this.clearTrackTimer()
-    // removeDJFromQueue may stop our stream and auto-start the next DJ's
-    // track — clear any watchdog armed for the old stream first.
-    this.room.clearTrackWatchdog()
+    // Watchdog lifecycle is owned by djHelpers (F2): removeDJFromQueue clears
+    // it when stopping our stream, and playTrackForCurrentDJ re-arms it if a
+    // promoted DJ's track auto-starts. No manual clear/re-arm needed here.
     removeDJFromQueue(this.room, this.sessionId)
     this.disconnectBooth()
     this.moveToStandby()
-    // Match message-handler behavior: re-arm for the promoted DJ's track.
-    this.room.startWatchdogIfPlaying()
   }
 
   private findFreeSlot(): number | null {
@@ -352,8 +350,10 @@ export class NpcDjManager {
     if (musicStream.status !== 'playing' || musicStream.streamId !== streamId) return
     if (state.currentDjSessionId !== this.sessionId) return
 
-    // Defensive: the watchdog isn't reliably cleared elsewhere — clear it
-    // before advancing so it can't double-advance behind us.
+    // Defensive only: armTrackTimer already cleared the watchdog when it
+    // claimed this stream, and the F2 centralization keeps clear/arm paired in
+    // djHelpers — but clearing again here is a free guarantee that nothing can
+    // double-advance behind us while we mutate rotation state.
     this.room.clearTrackWatchdog()
 
     const npc = state.players.get(this.sessionId)
@@ -371,11 +371,10 @@ export class NpcDjManager {
 
     // advanceRotation rotates the entry matching currentDjSessionId (F1 fix in
     // djHelpers.ts), so it is safe even if the queue was reordered under us.
+    // Its play/stop paths arm/clear the watchdog themselves (F2); if the next
+    // track is ours again, the next tick's armTrackTimer reclaims the stream
+    // by clearing that watchdog and arming our own timer.
     advanceRotation(this.room)
-
-    // Match message-handler behavior: arm the watchdog for whatever track just
-    // started. If it's ours again, the next tick's armTrackTimer reclaims it.
-    this.room.startWatchdogIfPlaying()
   }
 
   // ── Playlist ───────────────────────────────────────────────────────────────

--- a/server/src/rooms/NpcDjManager.ts
+++ b/server/src/rooms/NpcDjManager.ts
@@ -357,7 +357,9 @@ export class NpcDjManager {
     this.room.clearTrackWatchdog()
 
     const npc = state.players.get(this.sessionId)
-    if (npc) markTrackAsPlayed(npc)
+    // F7: pass the playing track's id — the stream is still 'playing' with a
+    // matching streamId here (checked above), so currentTrackId is valid.
+    if (npc) markTrackAsPlayed(npc, musicStream.currentTrackId)
 
     if (this.config.mode === 'fallback' && this.leaveAfterTrack) {
       console.log('[NpcDj] Track finished with humans waiting — leaving the queue')

--- a/server/src/rooms/NpcDjManager.ts
+++ b/server/src/rooms/NpcDjManager.ts
@@ -369,16 +369,9 @@ export class NpcDjManager {
     // (solo rotation) and immediately call playTrackForCurrentDJ.
     if (npc) this.ensureUnplayedTracks(npc)
 
-    // advanceRotation assumes djQueue[0] is the current DJ. If the queue was
-    // reordered under us, hand over via remove(+rejoin) instead.
-    if (state.djQueue.length > 0 && state.djQueue[0].sessionId === this.sessionId) {
-      advanceRotation(this.room)
-    } else {
-      console.warn('[NpcDj] Queue reordered under NPC — remove+rejoin instead of advanceRotation')
-      removeDJFromQueue(this.room, this.sessionId)
-      this.disconnectBooth()
-      if (this.config.mode === 'rotation') this.joinQueue()
-    }
+    // advanceRotation rotates the entry matching currentDjSessionId (F1 fix in
+    // djHelpers.ts), so it is safe even if the queue was reordered under us.
+    advanceRotation(this.room)
 
     // Match message-handler behavior: arm the watchdog for whatever track just
     // started. If it's ours again, the next tick's armTrackTimer reclaims it.

--- a/server/src/rooms/commands/DJQueueCommand.ts
+++ b/server/src/rooms/commands/DJQueueCommand.ts
@@ -1,192 +1,27 @@
 import { Command } from '@colyseus/command'
 import { Client } from 'colyseus'
 import type { ClubMutant } from '../ClubMutant'
-import { DJQueueEntry } from '@club-mutant/types/RoomState'
 import { Message } from '@club-mutant/types/Messages'
-import { playTrackForCurrentDJ } from './djHelpers'
+import {
+  advanceRotation,
+  joinDjQueue,
+  markTrackAsPlayed,
+  playTrackForCurrentDJ,
+  removeDJFromQueue,
+} from './djHelpers'
+
+// Re-exported for compatibility — the constant now lives with the queue helpers.
+export { MAX_DJ_QUEUE_SIZE } from './djHelpers'
 
 type Payload = {
   client: Client
   slotIndex?: number
 }
 
-// Helper function to find next DJ with tracks
-function hasUnplayedTracks(player: any): boolean {
-  for (let i = 0; i < player.roomQueuePlaylist.length; i++) {
-    if (!player.roomQueuePlaylist[i].played) return true
-  }
-  return false
-}
-
-function findNextDJWithTracks(room: ClubMutant): {
-  entry: DJQueueEntry | null
-  player: any | null
-} {
-  for (let i = 0; i < room.state.djQueue.length; i++) {
-    const entry = room.state.djQueue[i]
-    const player = room.state.players.get(entry.sessionId)
-    if (player && hasUnplayedTracks(player)) {
-      return { entry, player }
-    }
-  }
-  return { entry: null, player: null }
-}
-
-// Helper function to advance rotation
-function advanceRotation(room: ClubMutant) {
-  if (room.state.djQueue.length === 0) {
-    room.state.currentDjSessionId = null
-
-    // Stop music stream
-    const musicStream = room.state.musicStream
-    musicStream.status = 'waiting'
-    musicStream.currentLink = null
-    musicStream.currentTitle = null
-
-    console.log('[DJQueue] No more DJs, stopping music')
-    room.broadcast(Message.STOP_MUSIC_STREAM, {})
-    return
-  }
-
-  // Move current DJ to end of queue (if they still have tracks)
-  const currentEntry = room.state.djQueue[0]
-  const currentPlayer = room.state.players.get(currentEntry.sessionId)
-
-  room.state.djQueue.shift() // Remove from front
-
-  // If player still connected, move to end of queue (even without unplayed tracks —
-  // they can still add more tracks while at the booth). findNextDJWithTracks will
-  // skip them for playback if they have no unplayed tracks.
-  if (currentPlayer) {
-    const newEntry = new DJQueueEntry()
-    newEntry.sessionId = currentEntry.sessionId
-    newEntry.name = currentEntry.name
-    newEntry.joinedAtMs = Date.now()
-    newEntry.queuePosition = room.state.djQueue.length
-    newEntry.slotIndex = currentEntry.slotIndex
-    room.state.djQueue.push(newEntry)
-    console.log('[DJQueue] Moved DJ to end of queue:', currentEntry.sessionId)
-  } else {
-    console.log('[DJQueue] DJ removed from queue (disconnected):', currentEntry.sessionId)
-  }
-
-  // Update positions
-  room.state.djQueue.forEach((entry, i) => {
-    entry.queuePosition = i
-  })
-
-  // Find next DJ with tracks (skip those without)
-  const { entry: nextEntry, player: nextPlayer } = findNextDJWithTracks(room)
-
-  if (nextEntry && nextPlayer) {
-    // Move this DJ to the front of the queue
-    const index = room.state.djQueue.findIndex((e) => e.sessionId === nextEntry.sessionId)
-    if (index > 0) {
-      // Remove from current position and add to front
-      room.state.djQueue.splice(index, 1)
-      room.state.djQueue.unshift(nextEntry)
-      // Re-update positions
-      room.state.djQueue.forEach((entry, i) => {
-        entry.queuePosition = i
-      })
-    }
-
-    room.state.currentDjSessionId = nextEntry.sessionId
-    console.log('[DJQueue] New current DJ:', room.state.currentDjSessionId)
-    playTrackForCurrentDJ(room)
-  } else {
-    // No DJs with tracks - wait for someone to add tracks
-    room.state.currentDjSessionId = null
-
-    // Stop music stream
-    const musicStream = room.state.musicStream
-    musicStream.status = 'waiting'
-    musicStream.currentLink = null
-    musicStream.currentTitle = null
-
-    console.log('[DJQueue] No DJs with tracks, waiting...')
-    room.broadcast(Message.STOP_MUSIC_STREAM, {})
-  }
-
-  room.broadcast(Message.DJ_QUEUE_UPDATED, {
-    djQueue: room.state.djQueue.toArray(),
-    currentDjSessionId: room.state.currentDjSessionId,
-  })
-}
-
-// Helper function to mark track as played and move to bottom
-function markTrackAsPlayed(player: any) {
-  if (player.roomQueuePlaylist.length === 0) return
-
-  const track = player.roomQueuePlaylist[0]
-  if (!track) return
-
-  // Mark as played
-  track.played = true
-
-  // Move to the bottom of the queue
-  player.roomQueuePlaylist.push(track)
-  player.roomQueuePlaylist.shift()
-
-  console.log('[DJQueue] Marked track as played and moved to bottom:', track.title)
-}
-
-// Helper function to remove DJ from queue
-function removeDJFromQueue(room: ClubMutant, sessionId: string) {
-  const index = room.state.djQueue.findIndex((e) => e.sessionId === sessionId)
-  if (index < 0) return
-
-  const wasCurrentDJ = room.state.currentDjSessionId === sessionId
-  const wasPlaying = room.state.musicStream.status === 'playing'
-
-  console.log('[DJQueue] Removing from queue:', sessionId, wasCurrentDJ ? '(was current DJ)' : '')
-
-  // If current DJ was playing, stop their track first
-  if (wasCurrentDJ && wasPlaying) {
-    console.log('[DJQueue] Current DJ left during track, stopping playback')
-    const musicStream = room.state.musicStream
-    musicStream.status = 'waiting'
-    musicStream.currentLink = null
-    musicStream.currentTitle = null
-    room.broadcast(Message.STOP_MUSIC_STREAM, {})
-  }
-
-  // Remove the leaving DJ from the queue
-  room.state.djQueue.splice(index, 1)
-
-  // Reassign queue positions
-  room.state.djQueue.forEach((entry, i) => {
-    entry.queuePosition = i
-  })
-
-  if (wasCurrentDJ) {
-    // Promote next person in queue to current DJ (regardless of whether they have tracks)
-    const nextEntry = room.state.djQueue[0] ?? null
-
-    if (nextEntry) {
-      room.state.currentDjSessionId = nextEntry.sessionId
-      console.log('[DJQueue] Promoted next DJ:', nextEntry.sessionId)
-
-      // Auto-start the next DJ's track if they have one queued up
-      const nextPlayer = room.state.players.get(nextEntry.sessionId)
-
-      if (nextPlayer && nextPlayer.roomQueuePlaylist.length > 0) {
-        playTrackForCurrentDJ(room)
-      }
-    } else {
-      // Queue is empty
-      room.state.currentDjSessionId = null
-      console.log('[DJQueue] Queue empty, no current DJ')
-    }
-  }
-
-  room.broadcast(Message.DJ_QUEUE_UPDATED, {
-    djQueue: room.state.djQueue.toArray(),
-    currentDjSessionId: room.state.currentDjSessionId,
-  })
-}
-
-export const MAX_DJ_QUEUE_SIZE = 3
+// Thin wrappers over the djHelpers queue functions. Commands keep their
+// client.send(...) UI notifications; all queue/rotation logic lives in
+// djHelpers.ts so the NPC DJ manager can drive the same code paths without
+// a Colyseus Client.
 
 export class DJQueueJoinCommand extends Command<ClubMutant, Payload> {
   execute(data: Payload) {
@@ -194,71 +29,7 @@ export class DJQueueJoinCommand extends Command<ClubMutant, Payload> {
     const player = this.state.players.get(client.sessionId)
     if (!player) return
 
-    // Check if already in queue
-    const existingIndex = this.state.djQueue.findIndex(
-      (entry) => entry.sessionId === client.sessionId
-    )
-    if (existingIndex >= 0) return
-
-    // Enforce max queue size
-    if (this.state.djQueue.length >= MAX_DJ_QUEUE_SIZE) {
-      console.log('[DJQueue] Queue full, rejecting:', client.sessionId)
-      return
-    }
-
-    // Validate slotIndex (0, 1, or 2) and ensure it's not already taken
-    const slot =
-      typeof data.slotIndex === 'number' && data.slotIndex >= 0 && data.slotIndex <= 2
-        ? data.slotIndex
-        : 0
-
-    const slotTaken = this.state.djQueue.some((e) => e.slotIndex === slot)
-
-    if (slotTaken) {
-      console.log('[DJQueue] Slot', slot, 'already taken, rejecting:', client.sessionId)
-      return
-    }
-
-    // Add to queue
-    const entry = new DJQueueEntry()
-    entry.sessionId = client.sessionId
-    entry.name = player.name
-    entry.joinedAtMs = Date.now()
-    entry.queuePosition = this.state.djQueue.length
-    entry.slotIndex = slot
-
-    this.state.djQueue.push(entry)
-
-    // Teleport player behind the booth (must be server-authoritative so late-joining
-    // clients see the correct position — client sendPosition can be rejected by speed check)
-    const DJ_SLOT_SERVER_X = [100, 0, -100]
-    const BEHIND_BOOTH_SERVER_Y = 430
-
-    player.x = DJ_SLOT_SERVER_X[slot] ?? 0
-    player.y = BEHIND_BOOTH_SERVER_Y
-
-    console.log(
-      '[DJQueue] Joined:',
-      client.sessionId,
-      'Position:',
-      entry.queuePosition,
-      `teleported to (${player.x}, ${player.y})`
-    )
-
-    // If first DJ, set as current (playback requires explicit DJ_PLAY)
-    if (this.state.djQueue.length === 1) {
-      this.state.currentDjSessionId = client.sessionId
-      console.log('[DJQueue] First DJ, set as current:', client.sessionId)
-    } else if (!this.state.currentDjSessionId) {
-      // No current DJ — set this one as current
-      this.state.currentDjSessionId = client.sessionId
-      console.log('[DJQueue] No current DJ, set as current:', client.sessionId)
-    }
-
-    this.room.broadcast(Message.DJ_QUEUE_UPDATED, {
-      djQueue: this.state.djQueue.toArray(),
-      currentDjSessionId: this.state.currentDjSessionId,
-    })
+    joinDjQueue(this.room, client.sessionId, player.name, data.slotIndex)
   }
 }
 

--- a/server/src/rooms/commands/DJQueueCommand.ts
+++ b/server/src/rooms/commands/DJQueueCommand.ts
@@ -4,6 +4,7 @@ import type { ClubMutant } from '../ClubMutant'
 import { Message } from '@club-mutant/types/Messages'
 import {
   advanceRotation,
+  hasUnplayedTracks,
   joinDjQueue,
   markTrackAsPlayed,
   playTrackForCurrentDJ,
@@ -57,8 +58,10 @@ export class DJSkipTurnCommand extends Command<ClubMutant, Payload> {
 
     const player = this.state.players.get(client.sessionId)
     if (player) {
-      // Mark current track as played even when skipping
-      markTrackAsPlayed(player)
+      // Mark current track as played even when skipping (F7: by id — the
+      // playing track is not necessarily index 0; null while stopped falls
+      // back to legacy index-0 behavior)
+      markTrackAsPlayed(player, this.state.musicStream.currentTrackId)
 
       // Notify client so their playlist UI updates
       client.send(Message.ROOM_QUEUE_PLAYLIST_UPDATED, {
@@ -82,6 +85,33 @@ export class DJPlayCommand extends Command<ClubMutant, Payload> {
       if (!this.state.currentDjSessionId && inQueue) {
         this.state.currentDjSessionId = client.sessionId
         console.log('[DJQueue] No current DJ, promoted on play:', client.sessionId)
+      } else if (inQueue && this.state.musicStream.status !== 'playing') {
+        // F6: a current DJ with no unplayed tracks must not hold the booth
+        // hostage. When nothing is playing and a queued DJ asks to play,
+        // pass the turn instead of rejecting.
+        const currentPlayer = this.state.players.get(this.state.currentDjSessionId!)
+        if (currentPlayer && hasUnplayedTracks(currentPlayer)) {
+          console.log('[DJQueue] Play rejected - not current DJ:', client.sessionId)
+          return
+        }
+
+        console.log(
+          '[DJQueue] Trackless current DJ — passing turn on play request from:',
+          client.sessionId
+        )
+        advanceRotation(this.room)
+
+        if (this.state.currentDjSessionId !== client.sessionId) {
+          if (this.state.currentDjSessionId !== null) {
+            // Rotation promoted another DJ and started their track —
+            // the requester keeps waiting in queue order.
+            return
+          }
+          // Nobody had unplayed tracks — promote the requester so the
+          // loop-reset below can restart their playlist.
+          this.state.currentDjSessionId = client.sessionId
+          console.log('[DJQueue] No DJ with unplayed tracks, promoted requester:', client.sessionId)
+        }
       } else {
         console.log('[DJQueue] Play rejected - not current DJ:', client.sessionId)
         return
@@ -138,6 +168,7 @@ export class DJStopCommand extends Command<ClubMutant, Payload> {
     musicStream.status = 'waiting'
     musicStream.currentLink = null
     musicStream.currentTitle = null
+    musicStream.currentTrackId = null
 
     // F2: stop path owns the watchdog clear (handler no longer wraps this)
     this.room.clearTrackWatchdog()
@@ -179,8 +210,10 @@ export class DJTurnCompleteCommand extends Command<ClubMutant, TurnCompletePaylo
       return
     }
 
-    // Mark played track and move to bottom (keep history)
-    markTrackAsPlayed(player)
+    // Mark played track and move to bottom (keep history). F7: target the
+    // track that actually played (recorded when playTrackForCurrentDJ
+    // started it), not index 0.
+    markTrackAsPlayed(player, this.state.musicStream.currentTrackId)
 
     // Notify client so their playlist UI updates. The track watchdog (and any
     // NPC-related path) dispatches this command with a synthetic Client that

--- a/server/src/rooms/commands/DJQueueCommand.ts
+++ b/server/src/rooms/commands/DJQueueCommand.ts
@@ -18,6 +18,11 @@ type Payload = {
   slotIndex?: number
 }
 
+type TurnCompletePayload = {
+  client: Client
+  streamId?: number
+}
+
 // Thin wrappers over the djHelpers queue functions. Commands keep their
 // client.send(...) UI notifications; all queue/rotation logic lives in
 // djHelpers.ts so the NPC DJ manager can drive the same code paths without
@@ -138,9 +143,26 @@ export class DJStopCommand extends Command<ClubMutant, Payload> {
   }
 }
 
-export class DJTurnCompleteCommand extends Command<ClubMutant, Payload> {
-  execute(data: Payload) {
+export class DJTurnCompleteCommand extends Command<ClubMutant, TurnCompletePayload> {
+  execute(data: TurnCompletePayload) {
     const { client } = data
+
+    // Dedup (F4): only process if the streamId matches the current stream —
+    // mirrors the jukebox pattern (JukeboxTrackCompleteCommand). Prevents a
+    // late/duplicate completion (client onEnded racing the watchdog, or a
+    // double ▶▶ press) from marking/killing the track that just started.
+    if (
+      data.streamId !== undefined &&
+      data.streamId !== this.state.musicStream.streamId
+    ) {
+      console.log(
+        '[DJQueue] Turn complete ignored - streamId mismatch:',
+        data.streamId,
+        'vs',
+        this.state.musicStream.streamId
+      )
+      return
+    }
 
     // Only current DJ can complete their turn
     if (this.state.currentDjSessionId !== client.sessionId) {

--- a/server/src/rooms/commands/DJQueueCommand.ts
+++ b/server/src/rooms/commands/DJQueueCommand.ts
@@ -139,6 +139,8 @@ export class DJStopCommand extends Command<ClubMutant, Payload> {
     musicStream.currentLink = null
     musicStream.currentTitle = null
 
+    // F2: stop path owns the watchdog clear (handler no longer wraps this)
+    this.room.clearTrackWatchdog()
     this.room.broadcast(Message.STOP_MUSIC_STREAM, {})
   }
 }

--- a/server/src/rooms/commands/DJQueueCommand.ts
+++ b/server/src/rooms/commands/DJQueueCommand.ts
@@ -158,10 +158,14 @@ export class DJTurnCompleteCommand extends Command<ClubMutant, Payload> {
     // Mark played track and move to bottom (keep history)
     markTrackAsPlayed(player)
 
-    // Notify client so their playlist UI updates
-    client.send(Message.ROOM_QUEUE_PLAYLIST_UPDATED, {
-      items: [...player.roomQueuePlaylist],
-    })
+    // Notify client so their playlist UI updates. The track watchdog (and any
+    // NPC-related path) dispatches this command with a synthetic Client that
+    // only carries a sessionId — it has no send().
+    if (typeof client.send === 'function') {
+      client.send(Message.ROOM_QUEUE_PLAYLIST_UPDATED, {
+        items: [...player.roomQueuePlaylist],
+      })
+    }
 
     // ALWAYS advance to next DJ after playing one track
     console.log('[DJQueue] Track finished, advancing to next DJ')

--- a/server/src/rooms/commands/JukeboxCommand.ts
+++ b/server/src/rooms/commands/JukeboxCommand.ts
@@ -5,6 +5,7 @@ import type { ClubMutant } from '../ClubMutant'
 import { JukeboxItem, DJUserInfo } from '@club-mutant/types/RoomState'
 import { Message } from '@club-mutant/types/Messages'
 import { prefetchVideo } from '../../youtubeService'
+import { clampTrackDuration } from './djHelpers'
 
 type ClientPayload = {
   client: Client
@@ -109,7 +110,8 @@ export class JukeboxAddCommand extends Command<ClubMutant, AddPayload> {
     jukeboxItem.id = uuidv4()
     jukeboxItem.title = String(item.title)
     jukeboxItem.link = String(item.link)
-    jukeboxItem.duration = typeof item.duration === 'number' ? item.duration : 0
+    // F14: this value later drives the track watchdog — never trust it raw
+    jukeboxItem.duration = clampTrackDuration(item.duration)
     jukeboxItem.addedBySessionId = client.sessionId
     jukeboxItem.addedByName = player.name
     jukeboxItem.addedAtMs = Date.now()

--- a/server/src/rooms/commands/JukeboxCommand.ts
+++ b/server/src/rooms/commands/JukeboxCommand.ts
@@ -44,6 +44,9 @@ export function playNextJukeboxTrack(room: ClubMutant) {
   musicStream.streamId += 1
   musicStream.currentLink = track.link
   musicStream.currentTitle = track.title
+  // F7: currentTrackId refers to a DJ's roomQueuePlaylist item — a jukebox
+  // stream must not carry a stale id from a previous DJ-queue stream.
+  musicStream.currentTrackId = null
   musicStream.isAmbient = false
 
   const djInfo = new DJUserInfo()
@@ -73,6 +76,7 @@ export function stopJukeboxStream(room: ClubMutant) {
   musicStream.status = 'waiting'
   musicStream.currentLink = null
   musicStream.currentTitle = null
+  musicStream.currentTrackId = null
   musicStream.isAmbient = false
 
   console.log('[Jukebox] Stream stopped')

--- a/server/src/rooms/commands/JukeboxCommand.ts
+++ b/server/src/rooms/commands/JukeboxCommand.ts
@@ -55,7 +55,11 @@ export function playNextJukeboxTrack(room: ClubMutant) {
   musicStream.duration = track.duration
 
   console.log('[Jukebox] Playing track:', track.title, 'added by:', track.addedByName)
-  room.broadcast(Message.START_MUSIC_STREAM, { musicStream, offset: 0 })
+  // F12: keep the offset field truthful on every send path
+  room.broadcast(Message.START_MUSIC_STREAM, {
+    musicStream,
+    offset: (Date.now() - musicStream.startTime) / 1000,
+  })
 
   // Notify Lily NPC about the new track (she may comment spontaneously)
   room.notifyNpcMusicStarted(track.title)

--- a/server/src/rooms/commands/PunchPlayerCommand.ts
+++ b/server/src/rooms/commands/PunchPlayerCommand.ts
@@ -4,6 +4,7 @@ import { Client } from 'colyseus'
 import type { ClubMutant } from '../ClubMutant'
 import { Message } from '@club-mutant/types/Messages'
 import { TEXTURE_IDS, encodeAnimKey } from '@club-mutant/types/AnimationCodec'
+import { NPC_DJ_SESSION_PREFIX } from '../NpcDjManager'
 
 type Payload = {
   client: Client
@@ -19,6 +20,9 @@ export default class PunchPlayerCommand extends Command<ClubMutant, Payload> {
     if (!targetId) return
 
     if (targetId === data.client.sessionId) return
+
+    // The NPC automaton DJ can't be punched (would knock it off the booth)
+    if (targetId.startsWith(NPC_DJ_SESSION_PREFIX)) return
 
     const victim = this.state.players.get(targetId)
     if (!victim) return

--- a/server/src/rooms/commands/RoomQueuePlaylistCommand.ts
+++ b/server/src/rooms/commands/RoomQueuePlaylistCommand.ts
@@ -5,7 +5,7 @@ import type { ClubMutant } from '../ClubMutant'
 import { RoomQueuePlaylistItem } from '@club-mutant/types/RoomState'
 import { Message } from '@club-mutant/types/Messages'
 import { prefetchVideo } from '../../youtubeService'
-import { playTrackForCurrentDJ } from './djHelpers'
+import { playTrackForCurrentDJ, clampTrackDuration } from './djHelpers'
 
 type AddPayload = {
   client: Client
@@ -44,7 +44,8 @@ export class RoomQueuePlaylistAddCommand extends Command<ClubMutant, AddPayload>
     playlistItem.id = uuidv4()
     playlistItem.title = item.title
     playlistItem.link = item.link
-    playlistItem.duration = item.duration
+    // F14: this value later drives the track watchdog — never trust it raw
+    playlistItem.duration = clampTrackDuration(item.duration)
     playlistItem.addedAtMs = Date.now()
     playlistItem.played = false
 

--- a/server/src/rooms/commands/RoomQueuePlaylistCommand.ts
+++ b/server/src/rooms/commands/RoomQueuePlaylistCommand.ts
@@ -48,15 +48,19 @@ export class RoomQueuePlaylistAddCommand extends Command<ClubMutant, AddPayload>
     playlistItem.addedAtMs = Date.now()
     playlistItem.played = false
 
-    // Insert strategy: New tracks go after currently playing (if playing), otherwise at top
-    const isCurrentlyPlaying =
+    // Insert strategy: New tracks go after currently playing (if playing), otherwise at top.
+    // F7: locate the playing track by id — it is not necessarily index 0.
+    const playingIndex =
       this.state.currentDjSessionId === client.sessionId &&
-      this.state.musicStream.status === 'playing' &&
-      player.roomQueuePlaylist.length > 0
+      this.state.musicStream.status === 'playing'
+        ? player.roomQueuePlaylist.findIndex(
+            (t) => t.id === this.state.musicStream.currentTrackId
+          )
+        : -1
 
-    if (isCurrentlyPlaying) {
-      // Insert at index 1 (right after currently playing track)
-      player.roomQueuePlaylist.splice(1, 0, playlistItem)
+    if (playingIndex >= 0) {
+      // Insert right after the currently playing track
+      player.roomQueuePlaylist.splice(playingIndex + 1, 0, playlistItem)
     } else {
       // Insert at the top
       player.roomQueuePlaylist.unshift(playlistItem)
@@ -94,11 +98,12 @@ export class RoomQueuePlaylistRemoveCommand extends Command<ClubMutant, RemovePa
     const index = player.roomQueuePlaylist.findIndex((i) => i.id === itemId)
     if (index < 0) return
 
-    // Don't allow removing currently playing track
+    // Don't allow removing the currently playing track (F7: match by id —
+    // the playing track is not necessarily index 0)
     if (
       this.state.currentDjSessionId === client.sessionId &&
-      index === 0 &&
-      this.state.musicStream.status === 'playing'
+      this.state.musicStream.status === 'playing' &&
+      player.roomQueuePlaylist[index]?.id === this.state.musicStream.currentTrackId
     ) {
       console.log('[RoomQueuePlaylist] Remove rejected - cannot remove currently playing track')
       return
@@ -125,12 +130,15 @@ export class RoomQueuePlaylistReorderCommand extends Command<ClubMutant, Reorder
     if (fromIndex >= player.roomQueuePlaylist.length) return
     if (toIndex >= player.roomQueuePlaylist.length) return
 
-    // Don't allow reordering currently playing track
+    // Don't allow moving the currently playing track (F7: match by id — the
+    // playing track is not necessarily index 0). Moving OTHER tracks past it
+    // is safe now that played-marking targets ids instead of positions.
     if (
       this.state.currentDjSessionId === client.sessionId &&
       this.state.musicStream.status === 'playing'
     ) {
-      if (fromIndex === 0 || toIndex === 0) {
+      const movedItem = player.roomQueuePlaylist[fromIndex]
+      if (movedItem && movedItem.id === this.state.musicStream.currentTrackId) {
         console.log('[RoomQueuePlaylist] Reorder rejected - cannot move currently playing track')
         return
       }

--- a/server/src/rooms/commands/djHelpers.ts
+++ b/server/src/rooms/commands/djHelpers.ts
@@ -48,7 +48,12 @@ export function playTrackForCurrentDJ(room: ClubMutant) {
   musicStream.duration = track.duration
 
   console.log('[DJQueue] Playing track:', track.title, 'by DJ:', player.name)
-  room.broadcast(Message.START_MUSIC_STREAM, { musicStream, offset: 0 })
+  // F12: send the real elapsed offset (≈0 here since startTime was just set)
+  // so the field is truthful on every path — late joiners get a nonzero one.
+  room.broadcast(Message.START_MUSIC_STREAM, {
+    musicStream,
+    offset: (Date.now() - musicStream.startTime) / 1000,
+  })
   room.broadcast(Message.DJ_PLAY_STARTED, {
     djSessionId: djId,
     trackId: track.id,

--- a/server/src/rooms/commands/djHelpers.ts
+++ b/server/src/rooms/commands/djHelpers.ts
@@ -37,6 +37,9 @@ export function playTrackForCurrentDJ(room: ClubMutant) {
   musicStream.streamId += 1
   musicStream.currentLink = track.link
   musicStream.currentTitle = track.title
+  // F7: record WHICH item is playing so markTrackAsPlayed and the
+  // remove/reorder guards target the real track, not index 0.
+  musicStream.currentTrackId = track.id
   musicStream.isAmbient = false
 
   const djInfo = new DJUserInfo()
@@ -134,6 +137,7 @@ export function advanceRotation(room: ClubMutant) {
     musicStream.status = 'waiting'
     musicStream.currentLink = null
     musicStream.currentTitle = null
+    musicStream.currentTrackId = null
 
     console.log('[DJQueue] No more DJs, stopping music')
     room.clearTrackWatchdog() // F2: stop path kills the watchdog
@@ -208,6 +212,7 @@ export function advanceRotation(room: ClubMutant) {
     musicStream.status = 'waiting'
     musicStream.currentLink = null
     musicStream.currentTitle = null
+    musicStream.currentTrackId = null
 
     console.log('[DJQueue] No DJs with tracks, waiting...')
     room.clearTrackWatchdog() // F2: stop path kills the watchdog
@@ -220,19 +225,36 @@ export function advanceRotation(room: ClubMutant) {
   })
 }
 
-/** Mark the current track as played and move it to the bottom of the playlist. */
-export function markTrackAsPlayed(player: any) {
+/**
+ * Mark the played track and move it to the bottom of the playlist.
+ * F7: callers pass musicStream.currentTrackId so the track that ACTUALLY
+ * played gets marked — playTrackForCurrentDJ plays the first unplayed track,
+ * which can sit at index > 0 (e.g. after a while-stopped reorder). Falls back
+ * to index 0 when no id is available (legacy callers / nothing was playing).
+ */
+export function markTrackAsPlayed(player: any, trackId?: string | null) {
   if (player.roomQueuePlaylist.length === 0) return
 
-  const track = player.roomQueuePlaylist[0]
+  let index = 0
+  if (trackId) {
+    index = player.roomQueuePlaylist.findIndex((t: any) => t.id === trackId)
+    if (index < 0) {
+      // The played track is no longer in this playlist — mark nothing rather
+      // than flagging an innocent bystander at index 0.
+      console.log('[DJQueue] Played track not found in playlist, skipping mark:', trackId)
+      return
+    }
+  }
+
+  const track = player.roomQueuePlaylist[index]
   if (!track) return
 
   // Mark as played
   track.played = true
 
   // Move to the bottom of the queue
+  player.roomQueuePlaylist.splice(index, 1)
   player.roomQueuePlaylist.push(track)
-  player.roomQueuePlaylist.shift()
 
   console.log('[DJQueue] Marked track as played and moved to bottom:', track.title)
 }
@@ -254,6 +276,7 @@ export function removeDJFromQueue(room: ClubMutant, sessionId: string) {
     musicStream.status = 'waiting'
     musicStream.currentLink = null
     musicStream.currentTitle = null
+    musicStream.currentTrackId = null
     // F2: the leaving DJ's watchdog must die with their stream — if a new DJ
     // is promoted below, playTrackForCurrentDJ re-arms it for the new track.
     room.clearTrackWatchdog()
@@ -269,18 +292,43 @@ export function removeDJFromQueue(room: ClubMutant, sessionId: string) {
   })
 
   if (wasCurrentDJ) {
-    // Promote next person in queue to current DJ (regardless of whether they have tracks)
-    const nextEntry = room.state.djQueue[0] ?? null
+    // F5: promote like advanceRotation does — skip DJs with no UNPLAYED
+    // tracks instead of blindly promoting djQueue[0]. The old length check
+    // let a fully-played playlist through, playTrackForCurrentDJ no-opped,
+    // and the room stalled silently.
+    const { entry: nextEntry, player: nextPlayer } = findNextDJWithTracks(room)
 
-    if (nextEntry) {
+    if (nextEntry && nextPlayer) {
+      // Move this DJ to the front so queue order reflects the rotation
+      const nextIndex = room.state.djQueue.findIndex((e) => e.sessionId === nextEntry.sessionId)
+      if (nextIndex > 0) {
+        room.state.djQueue.splice(nextIndex, 1)
+        room.state.djQueue.unshift(nextEntry)
+        room.state.djQueue.forEach((entry, i) => {
+          entry.queuePosition = i
+        })
+      }
+
       room.state.currentDjSessionId = nextEntry.sessionId
-      console.log('[DJQueue] Promoted next DJ:', nextEntry.sessionId)
+      console.log('[DJQueue] Promoted next DJ with unplayed tracks:', nextEntry.sessionId)
+      playTrackForCurrentDJ(room)
+    } else if (room.state.djQueue.length > 0) {
+      // Nobody has unplayed tracks. Promote the head anyway (they hold the
+      // booth and can add tracks) — and if their playlist is merely
+      // exhausted, apply the same loop-reset DJPlayCommand does so the room
+      // keeps playing instead of stalling (F5).
+      const headEntry = room.state.djQueue[0]
+      room.state.currentDjSessionId = headEntry.sessionId
 
-      // Auto-start the next DJ's track if they have one queued up
-      const nextPlayer = room.state.players.get(nextEntry.sessionId)
-
-      if (nextPlayer && nextPlayer.roomQueuePlaylist.length > 0) {
+      const headPlayer = room.state.players.get(headEntry.sessionId)
+      if (headPlayer && headPlayer.roomQueuePlaylist.length > 0) {
+        console.log('[DJQueue] All tracks played — loop-reset for promoted DJ:', headEntry.sessionId)
+        for (let i = 0; i < headPlayer.roomQueuePlaylist.length; i++) {
+          headPlayer.roomQueuePlaylist[i].played = false
+        }
         playTrackForCurrentDJ(room)
+      } else {
+        console.log('[DJQueue] Promoted next DJ (no tracks):', headEntry.sessionId)
       }
     } else {
       // Queue is empty

--- a/server/src/rooms/commands/djHelpers.ts
+++ b/server/src/rooms/commands/djHelpers.ts
@@ -59,6 +59,13 @@ export function playTrackForCurrentDJ(room: ClubMutant) {
 
   // Prefetch the next DJ's first unplayed track so rotation is instant
   prefetchNextDJTrack(room, djId)
+
+  // F2/F3: the play path owns the watchdog. Every stream start (re-)arms it
+  // here so out-of-band advances (onLeave promotion, watchdog auto-advance,
+  // NPC rotation) can't leave a stale or missing watchdog. NpcDjManager
+  // clears this immediately after when it arms its own timer (armTrackTimer)
+  // — its timer is the sole timing authority for NPC tracks.
+  room.startWatchdogIfPlaying()
 }
 
 /**
@@ -124,6 +131,7 @@ export function advanceRotation(room: ClubMutant) {
     musicStream.currentTitle = null
 
     console.log('[DJQueue] No more DJs, stopping music')
+    room.clearTrackWatchdog() // F2: stop path kills the watchdog
     room.broadcast(Message.STOP_MUSIC_STREAM, {})
     return
   }
@@ -197,6 +205,7 @@ export function advanceRotation(room: ClubMutant) {
     musicStream.currentTitle = null
 
     console.log('[DJQueue] No DJs with tracks, waiting...')
+    room.clearTrackWatchdog() // F2: stop path kills the watchdog
     room.broadcast(Message.STOP_MUSIC_STREAM, {})
   }
 
@@ -240,6 +249,9 @@ export function removeDJFromQueue(room: ClubMutant, sessionId: string) {
     musicStream.status = 'waiting'
     musicStream.currentLink = null
     musicStream.currentTitle = null
+    // F2: the leaving DJ's watchdog must die with their stream — if a new DJ
+    // is promoted below, playTrackForCurrentDJ re-arms it for the new track.
+    room.clearTrackWatchdog()
     room.broadcast(Message.STOP_MUSIC_STREAM, {})
   }
 

--- a/server/src/rooms/commands/djHelpers.ts
+++ b/server/src/rooms/commands/djHelpers.ts
@@ -1,7 +1,15 @@
 import type { ClubMutant } from '../ClubMutant'
-import { DJUserInfo } from '@club-mutant/types/RoomState'
+import { DJQueueEntry, DJUserInfo } from '@club-mutant/types/RoomState'
 import { Message } from '@club-mutant/types/Messages'
 import { prefetchVideo } from '../../youtubeService'
+
+export const MAX_DJ_QUEUE_SIZE = 3
+
+// Server-authoritative DJ booth slot coordinates. Joining DJs are teleported here
+// so late-joining clients see the correct position (client sendPosition can be
+// rejected by the speed check).
+export const DJ_SLOT_SERVER_X = [100, 0, -100]
+export const BEHIND_BOOTH_SERVER_Y = 430
 
 /**
  * Play the first unplayed track in the current DJ's roomQueuePlaylist.
@@ -74,4 +82,262 @@ function prefetchNextDJTrack(room: ClubMutant, currentDjId: string) {
       }
     }
   }
+}
+
+// ─── DJ queue rotation helpers ──────────────────────────────────────────────
+// Shared by the DJQueue*Command wrappers and the NPC DJ manager. These must
+// never depend on a Colyseus `Client` — the NPC DJ has none. Commands keep
+// their client.send(...) UI notifications; everything else lives here.
+
+/** True if the player has at least one unplayed track in their room queue playlist. */
+export function hasUnplayedTracks(player: any): boolean {
+  for (let i = 0; i < player.roomQueuePlaylist.length; i++) {
+    if (!player.roomQueuePlaylist[i].played) return true
+  }
+  return false
+}
+
+/** Find the first DJ in the queue that has unplayed tracks. */
+export function findNextDJWithTracks(room: ClubMutant): {
+  entry: DJQueueEntry | null
+  player: any | null
+} {
+  for (let i = 0; i < room.state.djQueue.length; i++) {
+    const entry = room.state.djQueue[i]
+    const player = room.state.players.get(entry.sessionId)
+    if (player && hasUnplayedTracks(player)) {
+      return { entry, player }
+    }
+  }
+  return { entry: null, player: null }
+}
+
+/** Advance the DJ rotation: move current DJ to the end, promote next DJ with tracks. */
+export function advanceRotation(room: ClubMutant) {
+  if (room.state.djQueue.length === 0) {
+    room.state.currentDjSessionId = null
+
+    // Stop music stream
+    const musicStream = room.state.musicStream
+    musicStream.status = 'waiting'
+    musicStream.currentLink = null
+    musicStream.currentTitle = null
+
+    console.log('[DJQueue] No more DJs, stopping music')
+    room.broadcast(Message.STOP_MUSIC_STREAM, {})
+    return
+  }
+
+  // Move current DJ to end of queue (if they still have tracks)
+  const currentEntry = room.state.djQueue[0]
+  const currentPlayer = room.state.players.get(currentEntry.sessionId)
+
+  room.state.djQueue.shift() // Remove from front
+
+  // If player still connected, move to end of queue (even without unplayed tracks —
+  // they can still add more tracks while at the booth). findNextDJWithTracks will
+  // skip them for playback if they have no unplayed tracks.
+  if (currentPlayer) {
+    const newEntry = new DJQueueEntry()
+    newEntry.sessionId = currentEntry.sessionId
+    newEntry.name = currentEntry.name
+    newEntry.joinedAtMs = Date.now()
+    newEntry.queuePosition = room.state.djQueue.length
+    newEntry.slotIndex = currentEntry.slotIndex
+    room.state.djQueue.push(newEntry)
+    console.log('[DJQueue] Moved DJ to end of queue:', currentEntry.sessionId)
+  } else {
+    console.log('[DJQueue] DJ removed from queue (disconnected):', currentEntry.sessionId)
+  }
+
+  // Update positions
+  room.state.djQueue.forEach((entry, i) => {
+    entry.queuePosition = i
+  })
+
+  // Find next DJ with tracks (skip those without)
+  const { entry: nextEntry, player: nextPlayer } = findNextDJWithTracks(room)
+
+  if (nextEntry && nextPlayer) {
+    // Move this DJ to the front of the queue
+    const index = room.state.djQueue.findIndex((e) => e.sessionId === nextEntry.sessionId)
+    if (index > 0) {
+      // Remove from current position and add to front
+      room.state.djQueue.splice(index, 1)
+      room.state.djQueue.unshift(nextEntry)
+      // Re-update positions
+      room.state.djQueue.forEach((entry, i) => {
+        entry.queuePosition = i
+      })
+    }
+
+    room.state.currentDjSessionId = nextEntry.sessionId
+    console.log('[DJQueue] New current DJ:', room.state.currentDjSessionId)
+    playTrackForCurrentDJ(room)
+  } else {
+    // No DJs with tracks - wait for someone to add tracks
+    room.state.currentDjSessionId = null
+
+    // Stop music stream
+    const musicStream = room.state.musicStream
+    musicStream.status = 'waiting'
+    musicStream.currentLink = null
+    musicStream.currentTitle = null
+
+    console.log('[DJQueue] No DJs with tracks, waiting...')
+    room.broadcast(Message.STOP_MUSIC_STREAM, {})
+  }
+
+  room.broadcast(Message.DJ_QUEUE_UPDATED, {
+    djQueue: room.state.djQueue.toArray(),
+    currentDjSessionId: room.state.currentDjSessionId,
+  })
+}
+
+/** Mark the current track as played and move it to the bottom of the playlist. */
+export function markTrackAsPlayed(player: any) {
+  if (player.roomQueuePlaylist.length === 0) return
+
+  const track = player.roomQueuePlaylist[0]
+  if (!track) return
+
+  // Mark as played
+  track.played = true
+
+  // Move to the bottom of the queue
+  player.roomQueuePlaylist.push(track)
+  player.roomQueuePlaylist.shift()
+
+  console.log('[DJQueue] Marked track as played and moved to bottom:', track.title)
+}
+
+/** Remove a DJ from the queue, promoting the next entry if they were current. */
+export function removeDJFromQueue(room: ClubMutant, sessionId: string) {
+  const index = room.state.djQueue.findIndex((e) => e.sessionId === sessionId)
+  if (index < 0) return
+
+  const wasCurrentDJ = room.state.currentDjSessionId === sessionId
+  const wasPlaying = room.state.musicStream.status === 'playing'
+
+  console.log('[DJQueue] Removing from queue:', sessionId, wasCurrentDJ ? '(was current DJ)' : '')
+
+  // If current DJ was playing, stop their track first
+  if (wasCurrentDJ && wasPlaying) {
+    console.log('[DJQueue] Current DJ left during track, stopping playback')
+    const musicStream = room.state.musicStream
+    musicStream.status = 'waiting'
+    musicStream.currentLink = null
+    musicStream.currentTitle = null
+    room.broadcast(Message.STOP_MUSIC_STREAM, {})
+  }
+
+  // Remove the leaving DJ from the queue
+  room.state.djQueue.splice(index, 1)
+
+  // Reassign queue positions
+  room.state.djQueue.forEach((entry, i) => {
+    entry.queuePosition = i
+  })
+
+  if (wasCurrentDJ) {
+    // Promote next person in queue to current DJ (regardless of whether they have tracks)
+    const nextEntry = room.state.djQueue[0] ?? null
+
+    if (nextEntry) {
+      room.state.currentDjSessionId = nextEntry.sessionId
+      console.log('[DJQueue] Promoted next DJ:', nextEntry.sessionId)
+
+      // Auto-start the next DJ's track if they have one queued up
+      const nextPlayer = room.state.players.get(nextEntry.sessionId)
+
+      if (nextPlayer && nextPlayer.roomQueuePlaylist.length > 0) {
+        playTrackForCurrentDJ(room)
+      }
+    } else {
+      // Queue is empty
+      room.state.currentDjSessionId = null
+      console.log('[DJQueue] Queue empty, no current DJ')
+    }
+  }
+
+  room.broadcast(Message.DJ_QUEUE_UPDATED, {
+    djQueue: room.state.djQueue.toArray(),
+    currentDjSessionId: room.state.currentDjSessionId,
+  })
+}
+
+/**
+ * Join the DJ queue: queue-size/slot validation, entry creation,
+ * server-authoritative teleport to the booth slot, current-DJ promotion and
+ * DJ_QUEUE_UPDATED broadcast. Extracted from DJQueueJoinCommand.execute.
+ * Returns true if the join succeeded.
+ */
+export function joinDjQueue(
+  room: ClubMutant,
+  sessionId: string,
+  name: string,
+  slotIndex?: number
+): boolean {
+  const player = room.state.players.get(sessionId)
+  if (!player) return false
+
+  // Check if already in queue
+  const existingIndex = room.state.djQueue.findIndex((entry) => entry.sessionId === sessionId)
+  if (existingIndex >= 0) return false
+
+  // Enforce max queue size
+  if (room.state.djQueue.length >= MAX_DJ_QUEUE_SIZE) {
+    console.log('[DJQueue] Queue full, rejecting:', sessionId)
+    return false
+  }
+
+  // Validate slotIndex (0, 1, or 2) and ensure it's not already taken
+  const slot = typeof slotIndex === 'number' && slotIndex >= 0 && slotIndex <= 2 ? slotIndex : 0
+
+  const slotTaken = room.state.djQueue.some((e) => e.slotIndex === slot)
+
+  if (slotTaken) {
+    console.log('[DJQueue] Slot', slot, 'already taken, rejecting:', sessionId)
+    return false
+  }
+
+  // Add to queue
+  const entry = new DJQueueEntry()
+  entry.sessionId = sessionId
+  entry.name = name
+  entry.joinedAtMs = Date.now()
+  entry.queuePosition = room.state.djQueue.length
+  entry.slotIndex = slot
+
+  room.state.djQueue.push(entry)
+
+  // Teleport player behind the booth (must be server-authoritative so late-joining
+  // clients see the correct position — client sendPosition can be rejected by speed check)
+  player.x = DJ_SLOT_SERVER_X[slot] ?? 0
+  player.y = BEHIND_BOOTH_SERVER_Y
+
+  console.log(
+    '[DJQueue] Joined:',
+    sessionId,
+    'Position:',
+    entry.queuePosition,
+    `teleported to (${player.x}, ${player.y})`
+  )
+
+  // If first DJ, set as current (playback requires explicit DJ_PLAY)
+  if (room.state.djQueue.length === 1) {
+    room.state.currentDjSessionId = sessionId
+    console.log('[DJQueue] First DJ, set as current:', sessionId)
+  } else if (!room.state.currentDjSessionId) {
+    // No current DJ — set this one as current
+    room.state.currentDjSessionId = sessionId
+    console.log('[DJQueue] No current DJ, set as current:', sessionId)
+  }
+
+  room.broadcast(Message.DJ_QUEUE_UPDATED, {
+    djQueue: room.state.djQueue.toArray(),
+    currentDjSessionId: room.state.currentDjSessionId,
+  })
+
+  return true
 }

--- a/server/src/rooms/commands/djHelpers.ts
+++ b/server/src/rooms/commands/djHelpers.ts
@@ -128,27 +128,39 @@ export function advanceRotation(room: ClubMutant) {
     return
   }
 
-  // Move current DJ to end of queue (if they still have tracks)
-  const currentEntry = room.state.djQueue[0]
-  const currentPlayer = room.state.players.get(currentEntry.sessionId)
+  // Move the CURRENT DJ to the end of the queue. F1: rotate the entry matching
+  // state.currentDjSessionId — several promotion paths (join, DJ_PLAY
+  // auto-promote, playlist-add promote) set a current DJ that is NOT at
+  // index 0, so blindly rotating djQueue[0] starves that entry.
+  const currentDjId = room.state.currentDjSessionId
+  const currentIndex = currentDjId
+    ? room.state.djQueue.findIndex((e) => e.sessionId === currentDjId)
+    : -1
 
-  room.state.djQueue.shift() // Remove from front
+  if (currentIndex >= 0) {
+    const currentEntry = room.state.djQueue[currentIndex]
+    const currentPlayer = room.state.players.get(currentEntry.sessionId)
 
-  // If player still connected, move to end of queue (even without unplayed tracks —
-  // they can still add more tracks while at the booth). findNextDJWithTracks will
-  // skip them for playback if they have no unplayed tracks.
-  if (currentPlayer) {
-    const newEntry = new DJQueueEntry()
-    newEntry.sessionId = currentEntry.sessionId
-    newEntry.name = currentEntry.name
-    newEntry.joinedAtMs = Date.now()
-    newEntry.queuePosition = room.state.djQueue.length
-    newEntry.slotIndex = currentEntry.slotIndex
-    room.state.djQueue.push(newEntry)
-    console.log('[DJQueue] Moved DJ to end of queue:', currentEntry.sessionId)
-  } else {
-    console.log('[DJQueue] DJ removed from queue (disconnected):', currentEntry.sessionId)
+    room.state.djQueue.splice(currentIndex, 1) // Remove from current position
+
+    // If player still connected, move to end of queue (even without unplayed tracks —
+    // they can still add more tracks while at the booth). findNextDJWithTracks will
+    // skip them for playback if they have no unplayed tracks.
+    if (currentPlayer) {
+      const newEntry = new DJQueueEntry()
+      newEntry.sessionId = currentEntry.sessionId
+      newEntry.name = currentEntry.name
+      newEntry.joinedAtMs = Date.now()
+      newEntry.queuePosition = room.state.djQueue.length
+      newEntry.slotIndex = currentEntry.slotIndex
+      room.state.djQueue.push(newEntry)
+      console.log('[DJQueue] Moved DJ to end of queue:', currentEntry.sessionId)
+    } else {
+      console.log('[DJQueue] DJ removed from queue (disconnected):', currentEntry.sessionId)
+    }
   }
+  // currentIndex < 0: no current DJ (or they already left the queue) — nothing
+  // to rotate; fall through to promoting the next DJ with tracks.
 
   // Update positions
   room.state.djQueue.forEach((entry, i) => {

--- a/server/src/rooms/commands/djHelpers.ts
+++ b/server/src/rooms/commands/djHelpers.ts
@@ -104,6 +104,20 @@ function prefetchNextDJTrack(room: ClubMutant, currentDjId: string) {
 // never depend on a Colyseus `Client` — the NPC DJ has none. Commands keep
 // their client.send(...) UI notifications; everything else lives here.
 
+// F14: client-supplied durations drive the track watchdog — validate/clamp
+// them server-side. youtubeService has no metadata plumbing (it only
+// prefetches), so bounds are the best available validation: non-finite or
+// non-positive values become 0 ("unknown" — the watchdog arms a conservative
+// fallback instead of not arming), positives are clamped to [MIN, MAX].
+export const MIN_TRACK_DURATION_S = 5
+export const MAX_TRACK_DURATION_S = 4 * 60 * 60
+
+export function clampTrackDuration(raw: unknown): number {
+  const n = typeof raw === 'number' && Number.isFinite(raw) ? raw : 0
+  if (n <= 0) return 0
+  return Math.min(Math.max(n, MIN_TRACK_DURATION_S), MAX_TRACK_DURATION_S)
+}
+
 /** True if the player has at least one unplayed track in their room queue playlist. */
 export function hasUnplayedTracks(player: any): boolean {
   for (let i = 0; i < player.roomQueuePlaylist.length; i++) {
@@ -185,7 +199,30 @@ export function advanceRotation(room: ClubMutant) {
   })
 
   // Find next DJ with tracks (skip those without)
-  const { entry: nextEntry, player: nextPlayer } = findNextDJWithTracks(room)
+  let { entry: nextEntry, player: nextPlayer } = findNextDJWithTracks(room)
+
+  // F8: nobody has unplayed tracks but DJs are still queued — a full cycle
+  // just finished. Reset played flags and loop the rotation instead of
+  // stopping with DJs stranded at the booth in silence (recovery used to
+  // require a human pressing ▶).
+  if (!nextEntry && room.state.djQueue.length > 0) {
+    let anyReset = false
+    room.state.djQueue.forEach((entry) => {
+      const p = room.state.players.get(entry.sessionId)
+      if (!p) return
+      for (const t of p.roomQueuePlaylist) {
+        if (t.played) {
+          t.played = false
+          anyReset = true
+        }
+      }
+    })
+
+    if (anyReset) {
+      console.log('[DJQueue] All queued DJs exhausted — resetting played flags to loop rotation')
+      ;({ entry: nextEntry, player: nextPlayer } = findNextDJWithTracks(room))
+    }
+  }
 
   if (nextEntry && nextPlayer) {
     // Move this DJ to the front of the queue

--- a/server/src/rooms/npcPlaylists.ts
+++ b/server/src/rooms/npcPlaylists.ts
@@ -1,0 +1,91 @@
+// Curated playlists for the NPC automaton DJ.
+// See docs/plans/2026-07-05-npc-dj-design.md — Section 1.
+//
+// Playlist JSON files live in src/data/npc-playlists/ and are bundled into the
+// server build via JSON imports (resolveJsonModule + tsup). Durations ship in
+// the file so no YouTube lookups are needed at spawn.
+
+import defaultPlaylistJson from '../data/npc-playlists/default.json'
+
+export interface NpcPlaylistTrack {
+  id: string
+  title: string
+  link: string
+  duration: number
+}
+
+export interface NpcPlaylist {
+  id: string
+  name: string
+  tracks: NpcPlaylistTrack[]
+}
+
+// Registry of shipped playlists, keyed by playlist id.
+const RAW_PLAYLISTS: Record<string, unknown> = {
+  default: defaultPlaylistJson,
+}
+
+// Same shapes youtubeService.extractVideoId accepts (full URL or bare 11-char id)
+const YOUTUBE_LINK_PATTERNS = [
+  /(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/,
+  /^([a-zA-Z0-9_-]{11})$/,
+]
+
+function isYouTubeLink(link: string): boolean {
+  return YOUTUBE_LINK_PATTERNS.some((pattern) => pattern.test(link))
+}
+
+/**
+ * Load and validate an NPC playlist by id.
+ * Malformed entries are warned about and skipped; returns null (refuse spawn)
+ * if the playlist is unknown or has no valid tracks left after validation.
+ */
+export function loadNpcPlaylist(id: string): NpcPlaylist | null {
+  const raw = RAW_PLAYLISTS[id]
+
+  if (!raw || typeof raw !== 'object') {
+    console.warn('[NpcPlaylists] Unknown playlist id:', id)
+    return null
+  }
+
+  const playlist = raw as { id?: unknown; name?: unknown; tracks?: unknown }
+
+  if (!Array.isArray(playlist.tracks)) {
+    console.warn('[NpcPlaylists] Playlist has no tracks array:', id)
+    return null
+  }
+
+  const tracks: NpcPlaylistTrack[] = []
+
+  for (const entry of playlist.tracks) {
+    const track = entry as { id?: unknown; title?: unknown; link?: unknown; duration?: unknown }
+
+    const title = typeof track.title === 'string' ? track.title.trim() : ''
+    const link = typeof track.link === 'string' ? track.link.trim() : ''
+    const duration =
+      typeof track.duration === 'number' && Number.isFinite(track.duration) ? track.duration : 0
+
+    if (!title || !link || !isYouTubeLink(link) || duration <= 0) {
+      console.warn('[NpcPlaylists] Skipping malformed track in playlist', id, ':', entry)
+      continue
+    }
+
+    tracks.push({
+      id: typeof track.id === 'string' && track.id ? track.id : link,
+      title,
+      link,
+      duration,
+    })
+  }
+
+  if (tracks.length === 0) {
+    console.warn('[NpcPlaylists] Playlist empty after validation, refusing:', id)
+    return null
+  }
+
+  return {
+    id: typeof playlist.id === 'string' && playlist.id ? playlist.id : id,
+    name: typeof playlist.name === 'string' && playlist.name ? playlist.name : id,
+    tracks,
+  }
+}

--- a/types/RoomState.ts
+++ b/types/RoomState.ts
@@ -58,6 +58,9 @@ export class MusicStream extends Schema {
   @type('number') streamId = 0
   @type('string') currentLink: string | null = null
   @type('string') currentTitle: string | null = null
+  // F7: id of the playlist item that is actually playing — playTrackForCurrentDJ
+  // plays the first UNPLAYED track, which is not necessarily index 0.
+  @type('string') currentTrackId: string | null = null
   @type('string') currentVisualUrl: string | null = null
   @type('string') currentTrackMessage: string | null = null
   @type('number') currentBooth = 0

--- a/types/Rooms.ts
+++ b/types/Rooms.ts
@@ -8,6 +8,15 @@ export enum RoomType {
 
 export type MusicMode = 'djqueue' | 'jukebox' | 'personal'
 
+// NPC automaton DJ config (Phase 1: set at room creation / lobby env only).
+// See docs/plans/2026-07-05-npc-dj-design.md
+export interface INpcDjConfig {
+  mode: 'fallback' | 'rotation'
+  playlistId?: string // default: 'default'
+  name?: string // default: random pick from a name pool
+  textureId?: number // default: random of the sprites in TEXTURE_IDS
+}
+
 export interface IRoomData {
   name: string
   description: string
@@ -15,4 +24,5 @@ export interface IRoomData {
   autoDispose: boolean
   isPublic?: boolean
   musicMode?: MusicMode
+  npcDj?: INpcDjConfig
 }


### PR DESCRIPTION
## Part 1 — NPC automaton DJ (Phase 1)

A headless server-side Player that occupies a DJ booth slot and spins a curated playlist. No Colyseus Client — it drives the extracted, client-free rotation helpers directly.

- **Modes:** `fallback` (default — plays only while no humans are queued; finishes its current track and hands over when a human joins) and `rotation` (permanent queue member)
- **Config:** `IRoomData.npcDj` at room creation, or `NPC_DJ_LOBBY=fallback:default` env for the lobby
- Curated playlist (`server/src/data/npc-playlists/default.json`, 12 tracks) with shuffle + loop
- Chat announcements on track start; `[BOT]` badge in the queue UI; punch-proof
- Prep refactor: rotation helpers extracted from `DJQueueCommand.ts` into `djHelpers.ts` (zero behavior change)

Docs: `docs/plans/2026-07-05-npc-dj-design.md` + `docs/plans/2026-07-05-npc-dj-implementation.md`

## Part 2 — DJ queue hardening

A parallel audit (`docs/plans/2026-07-05-dj-queue-audit.md`, incl. resolutions section) found 14 issues; all fixed here, one commit per cluster:

- **F1+F4:** `advanceRotation` rotates the entry matching `currentDjSessionId` (was: blind `djQueue[0]` — turn theft/starvation); `DJ_TURN_COMPLETE` carries + validates `streamId` (no more stale double-advance)
- **F2+F3:** track-watchdog lifecycle centralized in the play/stop paths (onLeave race + never-re-arming watchdog fixed)
- **F10–F12:** late-join seek reliability — re-seek on `onReady`/`onStart`, periodic drift check vs `getCurrentTime()`, server-computed offset sent and consumed
- **F5–F7:** leave-promotion skips exhausted DJs; a trackless current DJ passes the turn; played-marking targets the actually-playing track id (new `currentTrackId` on stream state)
- **F8/F9/F13/F14:** full-cycle played-flag reset, `DJ_QUEUE_UPDATED` client handler, tick rehydration for missed STARTs, server-side duration clamping (5s–4h) + 10-min fallback watchdog for unknown durations

## Verification

- server: build ✅, vitest **24/24** (incl. new `djRotation.test.ts` regression suite for F1/F4/F5/F7/F8)
- types: **22/22** ✅ · client-3d: `tsc --noEmit` clean ✅
- Runtime verification still recommended for F10/F13/F14 (client seek behavior under slow loads)

## Suggested smoke test

Boot with `NPC_DJ_LOBBY=fallback:default`, join the lobby: NPC should be at the booth playing; queue up with a track → NPC finishes its song and hands over; leave the queue → NPC resumes.