### PR TITLE
fix(deploy): pin pnpm@10.25.0 in Dockerfile.server

### DIFF
--- a/Dockerfile.server
+++ b/Dockerfile.server
@@ -5,7 +5,7 @@ FROM ubuntu:24.04 AS builder
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
-    corepack enable && corepack prepare pnpm@latest --activate && \
+    corepack enable && corepack prepare pnpm@10.25.0 --activate && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -38,7 +38,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl ca-certificates python3 python3-pip ffmpeg && \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
-    corepack enable && corepack prepare pnpm@latest --activate && \
+    corepack enable && corepack prepare pnpm@10.25.0 --activate && \
     pip3 install --break-system-packages yt-dlp bgutil-ytdlp-pot-provider && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary

The Hetzner `server` deploy broke today. Root cause: `Dockerfile.server` installs pnpm via `corepack prepare pnpm@latest`, which is non-deterministic. The `server` image hadn't been rebuilt in ~3 months, so today's build pulled **pnpm 11.10.0** for the first time.

pnpm 11 turns ignored dependency build scripts (`@swc/core`, `sharp`, `@scarf/scarf`, …) into a **fatal error** (`ERR_PNPM_IGNORED_BUILDS`, exit 1) instead of a warning. That made `pnpm install --frozen-lockfile` fail and aborted the image build.

Verified locally: with **pnpm 10.25.0** (the version that generated `pnpm-lock.yaml`, lockfileVersion 9.0) the same install is a warning and succeeds; with pnpm 11 it's a hard error.

## Fix

Pin `corepack prepare pnpm@10.25.0` in both the builder and runtime stages so the build is reproducible and matches local dev.

## Deployment note

This exact change was already hotfixed directly on the Hetzner VPS to unblock today's DJ-queue + NPC-DJ deploy (PR #64), which is now live and verified (server, youtube-api InnerTube search, nakama all healthy). Merging this makes the fix permanent so the next `git pull` on the box doesn't revert it.

Optional follow-up (not in this PR): add `"packageManager": "pnpm@10.25.0"` to the root `package.json` for the same guarantee outside Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)