### PR TITLE
chore: pin pnpm@10.25.0 via packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "club-mutant",
   "version": "0.1.0",
   "description": "Server for Club Mutant",
+  "packageManager": "pnpm@10.25.0",
   "main": ".eslintrc.js",
   "scripts": {
     "start": "cd server && npm run start",


### PR DESCRIPTION
## Summary

Follow-up to #65. That PR pinned pnpm in `Dockerfile.server`; this adds the canonical `"packageManager": "pnpm@10.25.0"` field to the root `package.json`.

## Why

The Dockerfile pin only covers the `server` image build. Corepack, CI, and **Cloudflare Pages** all honor the root `packageManager` field, so without it the **client-3d Cloudflare Pages build** (and any other non-Docker `pnpm install`) can still auto-select pnpm 11.x and fail the same way #65 fixed — `ERR_PNPM_IGNORED_BUILDS` on native build scripts (`esbuild`, `sharp`, `@swc/core`, …).

`10.25.0` matches local dev and the `pnpm-lock.yaml` generator (lockfileVersion 9.0), and agrees with the version now pinned in `Dockerfile.server`.

## Risk

One-line, additive. Local pnpm is already 10.25.0 so there's no version-mismatch warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)