### PR TITLE
fix(client-3d): snap player entities to server position on mount

### DIFF
--- a/client-3d/src/scene/PlayerEntity.tsx
+++ b/client-3d/src/scene/PlayerEntity.tsx
@@ -102,6 +102,7 @@ export function PlayerEntity({ player, isLocal, characterPath }: PlayerEntityPro
   const [headTopY, setHeadTopY] = useState(1.1)
 
   const lastVisualX = useRef(0)
+  const didSpawnSnap = useRef(false)
   const stopTimer = useRef(0)
   const smoothSpeed = useRef(0)
   const smoothVelX = useRef(0)
@@ -128,6 +129,19 @@ export function PlayerEntity({ player, isLocal, characterPath }: PlayerEntityPro
     const pos = getPlayerPosition(player.sessionId)
     const targetX = (pos?.x ?? 0) * WORLD_SCALE
     const targetZ = -(pos?.y ?? 0) * WORLD_SCALE
+
+    // First frame after mount: snap straight to the server position. The group
+    // otherwise mounts at (0,0,0) and the lerp below visibly slides late-joiners'
+    // views of existing players from the world origin to their real spots.
+    // (playerHandlers.onAdd seeds the position map before this entity mounts.)
+    // Seeding lastVisualX too keeps the snap from registering as a huge visual
+    // velocity, which would flash the walk animation on frame one.
+    if (!didSpawnSnap.current && pos) {
+      didSpawnSnap.current = true
+      groupRef.current.position.x = targetX
+      groupRef.current.position.z = targetZ
+      lastVisualX.current = targetX
+    }
 
     const curX = groupRef.current.position.x
     const curZ = groupRef.current.position.z


### PR DESCRIPTION
## Problem

When joining a room with existing players, their avatars visibly slide from the world origin `(0,0)` to their actual positions over ~half a second.

## Root cause

`PlayerEntity`'s root `<group>` mounts at THREE's default `(0,0,0)` — it has no `position` prop and nothing seeds it. The `useFrame` loop then exponentially lerps (`REMOTE_LERP=8`) from wherever the group currently is toward the server position, producing the origin→spot glide.

The correct position is available *before* the entity ever mounts: `playerHandlers.onAdd` seeds `_playerPositions` before `gameStore.addPlayer` triggers the React render. Nothing consumed it at mount time.

It only shows for late-joiners because players who join *after* you spawn near origin anyway — but when **you** join a populated room, every existing player mounts at origin.

## Fix

One-time first-frame snap in `useFrame`: set the group's x/z straight to the seeded server position before the lerp runs, and seed `lastVisualX` so the snap doesn't register as a huge visual velocity (which would flash the walk animation on frame one).

No delayed rendering or visibility hacks needed — entities simply appear where they are.

## Verification

- `tsc --noEmit` clean
- Visual two-client verification planned alongside the NPC DJ smoke test (same dev-stack setup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)