### PR TITLE
YouTube streaming improvements: playlist import, precomputed FFT, proxy range caching

### DIFF
--- a/.claude
+++ b/.claude
@@ -1,0 +1,1 @@
+/Users/donny/Projects/2026/club-mutant/.claude

--- a/.claude
+++ b/.claude
@@ -1,1 +1,0 @@
-/Users/donny/Projects/2026/club-mutant/.claude

--- a/client-3d/src/hooks/useAudioAnalyser.ts
+++ b/client-3d/src/hooks/useAudioAnalyser.ts
@@ -9,6 +9,22 @@ const LOAD_TIMEOUT_MS = 12_000
 const FFT_SIZE = 256 // 128 frequency bins
 const SMOOTHING = 0.15 // Exponential smoothing factor for visual stability
 
+// Precomputed analysis timeline served by the Go service at /analysis/{videoId}.
+// When present, the client drives the visualizer from the synced playback
+// clock instead of opening a live silent audio stream per client.
+export interface PrecomputedAnalysis {
+  videoId: string
+  version: number
+  sampleRate: number
+  frameRate: number
+  frameCount: number
+  duration: number
+  bass: number[] // 0-255 per frame
+  mid: number[]
+  high: number[]
+  energy: number[]
+}
+
 // ── Module-level state (read imperatively by shader useFrame) ──────────
 export let audioBass = 0
 export let audioMid = 0
@@ -84,6 +100,7 @@ export function useAudioAnalyser() {
   const sourceRef = useRef<MediaElementAudioSourceNode | null>(null)
   const analyserRef = useRef<AnalyserNode | null>(null)
   const dataArrayRef = useRef<Uint8Array<ArrayBuffer> | null>(null)
+  const analysisRef = useRef<PrecomputedAnalysis | null>(null)
   const activeVideoIdRef = useRef<string | null>(null)
   const abortRef = useRef<AbortController | null>(null)
 
@@ -103,6 +120,7 @@ export function useAudioAnalyser() {
       }
       analyserRef.current = null
       dataArrayRef.current = null
+      analysisRef.current = null
 
       if (audioRef.current) {
         audioRef.current.pause()
@@ -130,8 +148,12 @@ export function useAudioAnalyser() {
       return
     }
 
-    // Don't restart if same video is already being analysed
-    if (activeVideoIdRef.current === videoId && audioRef.current && !audioRef.current.paused) {
+    // Don't restart if same video is already being analysed. Covers both
+    // paths: live analyser (audioRef set) and precomputed (analysisRef set).
+    if (
+      activeVideoIdRef.current === videoId &&
+      ((audioRef.current && !audioRef.current.paused) || analysisRef.current)
+    ) {
       return
     }
 
@@ -145,6 +167,29 @@ export function useAudioAnalyser() {
       if (abort.signal.aborted) return
 
       try {
+        // Prefer the precomputed analysis timeline (one-shot fetch, no
+        // persistent audio stream). If the service has it, we drive the
+        // visualizer purely from the synced playback clock and skip the
+        // <audio>/AudioContext entirely. On any non-200 (pending / not yet
+        // available / network error) we fall through to the live path.
+        const analysis = await getNetwork().fetchYouTubeAnalysis(videoId)
+        if (abort.signal.aborted) return
+
+        if (
+          analysis &&
+          analysis.version === 1 &&
+          analysis.frameCount > 0 &&
+          analysis.bass?.length === analysis.frameCount &&
+          analysis.mid?.length === analysis.frameCount &&
+          analysis.high?.length === analysis.frameCount &&
+          analysis.energy?.length === analysis.frameCount
+        ) {
+          analysisRef.current = analysis
+          audioAnalyserActive = true
+          console.log('[AudioAnalyser] Using precomputed analysis for:', videoId)
+          return
+        }
+
         const proxyUrl = getNetwork().getYouTubeAudioProxyUrl(videoId)
         if (abort.signal.aborted) return
 
@@ -232,6 +277,55 @@ export function useAudioAnalyser() {
 
   // Per-frame frequency analysis — writes to module-level exports
   useFrame(() => {
+    // Precomputed path: derive band values from the synced playback clock
+    // and the server-computed timeline. Reads the clock imperatively via
+    // getState() because subscribed hook values are stale inside this closure.
+    const analysis = analysisRef.current
+    if (analysis) {
+      const stream = useMusicStore.getState().stream
+      let pos = 0
+      if (stream.isPlaying && stream.startTime > 0) {
+        pos = (Date.now() - stream.startTime) / 1000
+      }
+
+      const fc = analysis.frameCount
+      const fr = analysis.frameRate
+      let rawBass: number
+      let rawMid: number
+      let rawHigh: number
+      let rawEnergy: number
+
+      if (pos < 0 || pos > analysis.duration + 0.5 || fc <= 0 || fr <= 0) {
+        // Past end / before start / not playing → decay target is 0 (the
+        // module-level lerp below handles the fade).
+        rawBass = 0
+        rawMid = 0
+        rawHigh = 0
+        rawEnergy = 0
+      } else {
+        // Frame index with linear interpolation between floor/ceil frames.
+        const exactFrame = pos * fr
+        const f0 = Math.max(0, Math.min(fc - 1, Math.floor(exactFrame)))
+        const f1 = Math.min(fc - 1, f0 + 1)
+        const frac = exactFrame - f0
+        const interp = (arr: number[], idx0: number, idx1: number) => {
+          const a = arr[idx0] ?? 0
+          const b = arr[idx1] ?? a
+          return (a + (b - a) * frac) / 255
+        }
+        rawBass = interp(analysis.bass, f0, f1)
+        rawMid = interp(analysis.mid, f0, f1)
+        rawHigh = interp(analysis.high, f0, f1)
+        rawEnergy = interp(analysis.energy, f0, f1)
+      }
+
+      audioBass = lerp(audioBass, rawBass, SMOOTHING)
+      audioMid = lerp(audioMid, rawMid, SMOOTHING)
+      audioHigh = lerp(audioHigh, rawHigh, SMOOTHING)
+      audioEnergy = lerp(audioEnergy, rawEnergy, SMOOTHING)
+      return
+    }
+
     const analyser = analyserRef.current
     const dataArray = dataArrayRef.current
     if (!analyser || !dataArray) return

--- a/client-3d/src/network/NetworkManager.ts
+++ b/client-3d/src/network/NetworkManager.ts
@@ -631,6 +631,27 @@ export class NetworkManager {
     return items
   }
 
+  // Fetch a public YouTube playlist via the Go service (InnerTube browse).
+  // Anonymous sessions cap out around 200 items; `truncated` signals a
+  // partial fetch and `declaredCount` (0 = unknown) the playlist's real size.
+  async fetchYouTubePlaylist(playlistId: string): Promise<{
+    playlistId: string
+    title: string
+    items: { videoId: string; title: string; duration: number; thumbnail?: string }[]
+    itemCount: number
+    declaredCount: number
+    truncated: boolean
+  }> {
+    const res = await fetch(`${this.youtubeBaseUrl}/playlist/${encodeURIComponent(playlistId)}`)
+    if (res.status === 404) throw new Error('Playlist not found (is it public?)')
+    if (res.status === 400) throw new Error('This playlist type cannot be imported')
+    if (!res.ok) throw new Error(`Playlist fetch failed (${res.status})`)
+
+    const data = await res.json()
+    data.items = data.items ?? []
+    return data
+  }
+
   // Resolve direct video URL for WebGL texture rendering
   async resolveYouTube(videoId: string): Promise<{ url: string; expiresAtMs: number | null }> {
     const res = await fetch(`${this.youtubeBaseUrl}/resolve/${videoId}`)

--- a/client-3d/src/network/NetworkManager.ts
+++ b/client-3d/src/network/NetworkManager.ts
@@ -3,6 +3,7 @@ import type { RoomState } from '@club-mutant/types/RoomState'
 import { Message } from '@club-mutant/types/Messages'
 import { RoomType } from '@club-mutant/types/Rooms'
 import type { RoomListEntry } from '../stores/gameStore'
+import type { PrecomputedAnalysis } from '../hooks/useAudioAnalyser'
 import { useAuthStore } from '../stores/authStore'
 import { getValidToken } from './nakamaClient'
 
@@ -668,6 +669,20 @@ export class NetworkManager {
   // Get proxied audio-only URL for frequency analysis (48kbps AAC, ~360KB/min)
   getYouTubeAudioProxyUrl(videoId: string): string {
     return `${this.youtubeBaseUrl}/proxy/${videoId}?audioOnly=true&videoOnly=false`
+  }
+
+  // Fetch the precomputed FFT analysis timeline for a video. Returns null on
+  // ANY non-200 (202 pending / 404 unavailable / network error) so callers
+  // fall back to the live audio analyser path.
+  async fetchYouTubeAnalysis(videoId: string): Promise<PrecomputedAnalysis | null> {
+    try {
+      const res = await fetch(`${this.youtubeBaseUrl}/analysis/${videoId}`)
+      if (!res.ok) return null
+      const data = (await res.json()) as PrecomputedAnalysis
+      return data
+    } catch {
+      return null
+    }
   }
 
   get sessionId(): string | undefined {

--- a/client-3d/src/network/nakamaClient.ts
+++ b/client-3d/src/network/nakamaClient.ts
@@ -402,6 +402,14 @@ interface ServerPlaylist {
   updatedAt: number
 }
 
+export interface ServerPlaylistMeta {
+  id: string
+  name: string
+  trackCount: number
+  createdAt: number
+  updatedAt: number
+}
+
 /**
  * Fetch all playlists from Nakama, paginating through all pages.
  */
@@ -420,6 +428,39 @@ export async function listServerPlaylists(): Promise<ServerPlaylist[]> {
   } while (cursor)
 
   return all
+}
+
+/**
+ * Fetch playlist metadata only (no items) — lightweight startup listing for
+ * lazy item loading. Requires the get_playlist/include_items Nakama module.
+ */
+export async function listServerPlaylistsMeta(): Promise<ServerPlaylistMeta[]> {
+  const session = await ensureSession()
+  const all: ServerPlaylistMeta[] = []
+  let cursor: string | null = null
+
+  do {
+    const params: Record<string, unknown> = { include_items: false }
+    if (cursor) params.cursor = cursor
+    const result = await getClient().rpc(session, 'list_playlists', params)
+    const data = result.payload as { playlists: ServerPlaylistMeta[]; cursor: string | null }
+    if (data.playlists) {
+      for (const p of data.playlists) all.push(p)
+    }
+    cursor = data.cursor || null
+  } while (cursor)
+
+  return all
+}
+
+/**
+ * Fetch one playlist with its full items list.
+ */
+export async function getServerPlaylist(id: string): Promise<ServerPlaylist> {
+  const session = await ensureSession()
+  const result = await getClient().rpc(session, 'get_playlist', { id })
+  const data = result.payload as { playlist: ServerPlaylist }
+  return data.playlist
 }
 
 /**

--- a/client-3d/src/stores/playlistStore.ts
+++ b/client-3d/src/stores/playlistStore.ts
@@ -1,12 +1,19 @@
 import { create } from 'zustand'
 import { useAuthStore } from './authStore'
 import {
-  listServerPlaylists,
+  listServerPlaylistsMeta,
+  getServerPlaylist,
   saveServerPlaylist,
   deleteServerPlaylist,
 } from '../network/nakamaClient'
 
 const STORAGE_KEY = 'club-mutant-3d:playlists:v1'
+
+// Mirrors MAX_PLAYLIST_NAME / MAX_TRACKS_PER_PLAYLIST / MAX_PLAYLISTS in
+// nakama/modules/index.js — the server silently truncates past these.
+export const MAX_PLAYLIST_NAME = 60
+export const IMPORT_MAX_TRACKS = 500
+export const MAX_PLAYLISTS = 100
 
 export interface PlaylistTrack {
   id: string
@@ -20,6 +27,12 @@ export interface MyPlaylist {
   id: string
   name: string
   items: PlaylistTrack[]
+  // false when only metadata has been fetched from the server (lazy
+  // loading) — items may be stale or empty until ensureItemsLoaded runs.
+  // Absent/true means items are authoritative and safe to sync.
+  itemsLoaded?: boolean
+  // Server-declared item count, shown while items are not yet loaded.
+  trackCount?: number
 }
 
 interface PlaylistState {
@@ -29,12 +42,14 @@ interface PlaylistState {
   lastSyncError: string | null
 
   createPlaylist: (name: string) => void
+  importPlaylist: (name: string, tracks: PlaylistTrack[]) => string
   removePlaylist: (id: string) => void
   renamePlaylist: (id: string, name: string) => void
   setActivePlaylist: (id: string | null) => void
   addTrack: (playlistId: string, track: PlaylistTrack) => void
   removeTrack: (playlistId: string, trackId: string) => void
   reorderTrack: (playlistId: string, fromIndex: number, toIndex: number) => void
+  ensureItemsLoaded: (playlistId: string) => Promise<void>
   loadFromServer: () => Promise<void>
 }
 
@@ -93,6 +108,18 @@ function scheduleSyncPlaylist(playlistId: string) {
       _syncTimers.delete(playlistId)
       const playlist = usePlaylistStore.getState().playlists.find((p) => p.id === playlistId)
       if (!playlist) return
+      // Data-loss guard: never save a lazily-listed playlist whose items
+      // haven't been fetched — it would overwrite server items with the
+      // stale/empty local copy. Fetch items first, then re-sync (this
+      // preserves metadata-only changes like renames).
+      if (playlist.itemsLoaded === false) {
+        usePlaylistStore
+          .getState()
+          .ensureItemsLoaded(playlistId)
+          .then(() => scheduleSyncPlaylist(playlistId))
+          .catch((err) => console.warn('[playlists] Deferred sync failed for', playlistId, err))
+        return
+      }
       saveServerPlaylist({ id: playlist.id, name: playlist.name, items: playlist.items }).catch(
         (err) => {
           console.warn('[playlists] Server sync failed for', playlistId, err)
@@ -119,6 +146,18 @@ function scheduleDeletePlaylist(playlistId: string) {
   })
 }
 
+// itemsMutationAllowed blocks item edits on playlists whose items haven't
+// been fetched yet (they'd operate on a stale/empty copy). Kicks off the
+// fetch so a retry succeeds; UIs should call ensureItemsLoaded before
+// showing items, making this a belt-and-braces guard.
+function itemsMutationAllowed(playlistId: string, action: string): boolean {
+  const playlist = usePlaylistStore.getState().playlists.find((p) => p.id === playlistId)
+  if (!playlist || playlist.itemsLoaded !== false) return true
+  console.warn(`[playlists] ${action} blocked: playlist ${playlistId} items not loaded yet`)
+  void usePlaylistStore.getState().ensureItemsLoaded(playlistId)
+  return false
+}
+
 // ── Store ──────────────────────────────────────────────────────────────────
 
 const initial = loadPersisted()
@@ -143,6 +182,25 @@ export const usePlaylistStore = create<PlaylistState>((set, get) => ({
     })
 
     scheduleSyncPlaylist(id)
+  },
+
+  importPlaylist: (name, tracks) => {
+    const id = crypto.randomUUID()
+    const trimmedName = (name || 'YouTube Playlist').trim().substring(0, MAX_PLAYLIST_NAME)
+    const items = tracks.slice(0, IMPORT_MAX_TRACKS)
+
+    set((s) => {
+      const next = {
+        playlists: [...s.playlists, { id, name: trimmedName, items, itemsLoaded: true }],
+        activePlaylistId: s.activePlaylistId ?? id,
+      }
+
+      persistLocal(next)
+      return next
+    })
+
+    scheduleSyncPlaylist(id)
+    return id
   },
 
   removePlaylist: (id) => {
@@ -183,6 +241,7 @@ export const usePlaylistStore = create<PlaylistState>((set, get) => ({
   },
 
   addTrack: (playlistId, track) => {
+    if (!itemsMutationAllowed(playlistId, 'addTrack')) return
     set((s) => {
       const next = {
         playlists: s.playlists.map((p) =>
@@ -199,6 +258,7 @@ export const usePlaylistStore = create<PlaylistState>((set, get) => ({
   },
 
   removeTrack: (playlistId, trackId) => {
+    if (!itemsMutationAllowed(playlistId, 'removeTrack')) return
     set((s) => {
       const next = {
         playlists: s.playlists.map((p) =>
@@ -215,6 +275,7 @@ export const usePlaylistStore = create<PlaylistState>((set, get) => ({
   },
 
   reorderTrack: (playlistId, fromIndex, toIndex) => {
+    if (!itemsMutationAllowed(playlistId, 'reorderTrack')) return
     set((s) => {
       const next = {
         playlists: s.playlists.map((p) => {
@@ -236,34 +297,79 @@ export const usePlaylistStore = create<PlaylistState>((set, get) => ({
     scheduleSyncPlaylist(playlistId)
   },
 
+  ensureItemsLoaded: async (playlistId) => {
+    const playlist = get().playlists.find((p) => p.id === playlistId)
+    if (!playlist || playlist.itemsLoaded !== false) return
+    if (!isAuthenticated()) return
+
+    try {
+      const server = await getServerPlaylist(playlistId)
+      set((s) => {
+        const next = {
+          playlists: s.playlists.map((p) =>
+            p.id === playlistId
+              ? // Keep the local name (a rename may be pending sync); items
+                // come from the server as the authoritative copy.
+                { ...p, items: server.items || [], itemsLoaded: true, trackCount: undefined }
+              : p
+          ),
+          activePlaylistId: s.activePlaylistId,
+        }
+        persistLocal(next)
+        return next
+      })
+    } catch (err) {
+      console.warn('[playlists] Failed to load items for', playlistId, err)
+      set({ lastSyncError: String(err) })
+      throw err
+    }
+  },
+
   loadFromServer: async () => {
     if (!isAuthenticated()) return
 
     set({ syncing: true, lastSyncError: null })
 
     try {
-      const serverPlaylists = await listServerPlaylists()
+      const serverPlaylists = await listServerPlaylistsMeta()
       const localPlaylists = get().playlists
-
-      // Build a map of server playlists by ID
-      const serverMap = new Map<string, MyPlaylist>()
-      for (const sp of serverPlaylists) {
-        serverMap.set(sp.id, { id: sp.id, name: sp.name, items: sp.items })
+      const localMap = new Map<string, MyPlaylist>()
+      for (const lp of localPlaylists) {
+        localMap.set(lp.id, lp)
       }
+
+      const serverIds = new Set(serverPlaylists.map((sp) => sp.id))
 
       // Find local-only playlists (not on server) to upload
       const localOnly: MyPlaylist[] = []
       for (const lp of localPlaylists) {
-        if (!serverMap.has(lp.id)) {
+        if (!serverIds.has(lp.id)) {
           localOnly.push(lp)
         }
       }
 
-      // Merged result: server playlists + local-only playlists
-      const merged = [...serverPlaylists.map((sp) => ({ id: sp.id, name: sp.name, items: sp.items })), ...localOnly]
+      // Server playlists: metadata from the server, items lazily loaded.
+      // The locally persisted copy serves as a warm cache; when its item
+      // count matches the server's we trust it, otherwise mark unloaded so
+      // ensureItemsLoaded refreshes on open.
+      const fromServer: MyPlaylist[] = serverPlaylists.map((sp) => {
+        const local = localMap.get(sp.id)
+        const localItems = local?.items ?? []
+        const upToDate = local?.itemsLoaded !== false && localItems.length === sp.trackCount
+        return {
+          id: sp.id,
+          name: sp.name,
+          items: localItems,
+          itemsLoaded: upToDate,
+          trackCount: upToDate ? undefined : sp.trackCount,
+        }
+      })
+
+      const merged = [...fromServer, ...localOnly]
 
       // Upload local-only playlists to server
       for (const lp of localOnly) {
+        if (lp.itemsLoaded === false) continue // never upload an unloaded copy
         saveServerPlaylist({ id: lp.id, name: lp.name, items: lp.items }).catch((err) =>
           console.warn('[playlists] Failed to upload local playlist', lp.id, err)
         )
@@ -279,11 +385,16 @@ export const usePlaylistStore = create<PlaylistState>((set, get) => ({
       persistLocal({ playlists: merged, activePlaylistId: nextActive })
 
       console.log(
-        '[playlists] Loaded from server: %d server, %d local-only, %d total',
+        '[playlists] Loaded from server: %d server (meta), %d local-only, %d total',
         serverPlaylists.length,
         localOnly.length,
         merged.length
       )
+
+      // Warm the active playlist's items so the primary view is ready.
+      if (nextActive) {
+        void get().ensureItemsLoaded(nextActive)
+      }
     } catch (err) {
       console.warn('[playlists] Failed to load from server:', err)
       set({ syncing: false, lastSyncError: String(err) })

--- a/client-3d/src/ui/MyPlaylistsPanel.tsx
+++ b/client-3d/src/ui/MyPlaylistsPanel.tsx
@@ -5,7 +5,13 @@ import { useToastStore } from '../stores/toastStore'
 import { useGameStore } from '../stores/gameStore'
 import { useJukeboxStore } from '../stores/jukeboxStore'
 import { useBoothStore } from '../stores/boothStore'
-import { usePlaylistStore, type PlaylistTrack } from '../stores/playlistStore'
+import {
+  usePlaylistStore,
+  IMPORT_MAX_TRACKS,
+  MAX_PLAYLISTS,
+  type PlaylistTrack,
+} from '../stores/playlistStore'
+import { extractPlaylistId } from '../utils/youtubePlaylist'
 
 interface SearchResult {
   title: string
@@ -76,6 +82,11 @@ export function MyPlaylistsPanel() {
   // Playlist management
   const [newPlaylistName, setNewPlaylistName] = useState('')
   const [creating, setCreating] = useState(false)
+
+  // YouTube playlist import
+  const [importUrl, setImportUrl] = useState('')
+  const [importOpen, setImportOpen] = useState(false)
+  const [importing, setImporting] = useState(false)
 
   const [recentlyAdded, setRecentlyAdded] = useState<Set<string>>(new Set())
 
@@ -163,6 +174,50 @@ export function MyPlaylistsPanel() {
     setCreating(false)
   }
 
+  const handleImportPlaylist = async () => {
+    const toast = useToastStore.getState().addToast
+    const playlistId = extractPlaylistId(importUrl)
+    if (!playlistId) {
+      toast('invalid playlist url (mixes & private lists not supported)')
+      return
+    }
+    if (usePlaylistStore.getState().playlists.length >= MAX_PLAYLISTS) {
+      toast(`playlist limit reached (max ${MAX_PLAYLISTS})`)
+      return
+    }
+
+    setImporting(true)
+    try {
+      const data = await getNetwork().fetchYouTubePlaylist(playlistId)
+      if (data.items.length === 0) {
+        toast('playlist is empty or unavailable')
+        return
+      }
+      const tracks: PlaylistTrack[] = data.items.map((it) => ({
+        id: crypto.randomUUID(),
+        title: it.title,
+        link: `https://www.youtube.com/watch?v=${it.videoId}`,
+        duration: it.duration,
+        thumbnail: it.thumbnail,
+      }))
+      const imported = Math.min(tracks.length, IMPORT_MAX_TRACKS)
+      usePlaylistStore.getState().importPlaylist(data.title, tracks)
+
+      const total = data.declaredCount > imported ? data.declaredCount : tracks.length
+      if (data.truncated || tracks.length > IMPORT_MAX_TRACKS) {
+        toast(`imported first ${imported} of ${total} tracks`)
+      } else {
+        toast(`imported ${imported} tracks`)
+      }
+      setImportUrl('')
+      setImportOpen(false)
+    } catch (err) {
+      toast(err instanceof Error ? err.message : 'playlist import failed')
+    } finally {
+      setImporting(false)
+    }
+  }
+
   const handleAddTrackToQueue = (track: PlaylistTrack) => {
     if (isJukeboxMode) {
       getNetwork().addToJukebox(track.title, track.link, track.duration)
@@ -245,11 +300,14 @@ export function MyPlaylistsPanel() {
                 : `+ add all to ${queueLabel}`}
             </button>
           )}
-          {viewingPlaylist.items.length === 0 && (
-            <p className="text-white/40 text-[12px] font-mono text-center mt-4">
-              no tracks yet — use Search or Link tabs to add
-            </p>
-          )}
+          {viewingPlaylist.items.length === 0 &&
+            (viewingPlaylist.itemsLoaded === false ? (
+              <p className="text-white/40 text-[12px] font-mono text-center mt-4">loading tracks…</p>
+            ) : (
+              <p className="text-white/40 text-[12px] font-mono text-center mt-4">
+                no tracks yet — use Search or Link tabs to add
+              </p>
+            ))}
           {viewingPlaylist.items.map((track, i) => (
             <div
               key={track.id}
@@ -426,12 +484,16 @@ export function MyPlaylistsPanel() {
             setViewingPlaylistId(pl.id)
             setDetailTab('tracks')
             usePlaylistStore.getState().setActivePlaylist(pl.id)
+            void usePlaylistStore.getState().ensureItemsLoaded(pl.id)
           }}
         >
           <div className="min-w-0 flex-1">
             <div className="text-[14px] font-mono text-white/90">{pl.name}</div>
             <div className="text-[11px] font-mono text-white/50">
-              {pl.items.length} track{pl.items.length !== 1 ? 's' : ''}
+              {(() => {
+                const count = pl.itemsLoaded === false ? (pl.trackCount ?? 0) : pl.items.length
+                return `${count} track${count !== 1 ? 's' : ''}`
+              })()}
             </div>
           </div>
           <div className="flex gap-1 flex-shrink-0">
@@ -496,6 +558,44 @@ export function MyPlaylistsPanel() {
           className="mt-2 w-full py-1 text-[12px] font-mono text-white/50 hover:text-white/80 border border-dashed border-white/10 hover:border-white/20 rounded transition-colors"
         >
           + new playlist
+        </button>
+      )}
+
+      {importOpen ? (
+        <div className="flex gap-1 mt-2">
+          <input
+            type="text"
+            value={importUrl}
+            onChange={(e) => setImportUrl(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && !importing && handleImportPlaylist()}
+            placeholder="paste youtube playlist url..."
+            className="flex-1 bg-white/5 border border-white/10 rounded px-2.5 py-1 text-[13px] text-white placeholder-white/30 focus:border-red-400/50 focus:outline-none font-mono"
+            autoFocus
+            disabled={importing}
+          />
+          <button
+            onClick={handleImportPlaylist}
+            disabled={importing}
+            className="px-2.5 py-1 text-[13px] font-mono bg-red-500/20 border border-red-500/30 rounded text-red-400 hover:bg-red-500/30 transition-colors disabled:opacity-50"
+          >
+            {importing ? '...' : 'import'}
+          </button>
+          <button
+            onClick={() => {
+              setImportOpen(false)
+              setImportUrl('')
+            }}
+            className="px-2 py-1 text-[13px] font-mono text-white/50 hover:text-white transition-colors"
+          >
+            ✕
+          </button>
+        </div>
+      ) : (
+        <button
+          onClick={() => setImportOpen(true)}
+          className="mt-1.5 w-full py-1 text-[12px] font-mono text-white/50 hover:text-white/80 border border-dashed border-white/10 hover:border-white/20 rounded transition-colors"
+        >
+          ⇩ import from youtube
         </button>
       )}
     </div>

--- a/client-3d/src/ui/konpyuuta/KonpyuuTAShell.tsx
+++ b/client-3d/src/ui/konpyuuta/KonpyuuTAShell.tsx
@@ -30,10 +30,13 @@ export function KonpyuuTAShell() {
     return {
       getPlaylists: () => store().playlists,
       createPlaylist: (name: string) => store().createPlaylist(name),
+      importPlaylist: (name: string, tracks: PlaylistTrack[]) =>
+        store().importPlaylist(name, tracks),
       removePlaylist: (id: string) => store().removePlaylist(id),
       addTrack: (playlistId: string, track: PlaylistTrack) => store().addTrack(playlistId, track),
       removeTrack: (playlistId: string, trackId: string) =>
         store().removeTrack(playlistId, trackId),
+      ensureItemsLoaded: (playlistId: string) => store().ensureItemsLoaded(playlistId),
       loadFromServer: () => store().loadFromServer(),
     }
   }, [])

--- a/client-3d/src/utils/youtubePlaylist.ts
+++ b/client-3d/src/utils/youtubePlaylist.ts
@@ -1,0 +1,48 @@
+// YouTube playlist URL/ID parsing for the import feature.
+
+const PLAYLIST_ID_REGEX = /^[A-Za-z0-9_-]{10,64}$/
+
+const YOUTUBE_HOSTS = new Set([
+  'youtube.com',
+  'www.youtube.com',
+  'm.youtube.com',
+  'music.youtube.com',
+  'youtu.be',
+])
+
+// Mixes (RD*) and auth-required lists (Watch Later, Liked) cannot be fetched
+// anonymously via InnerTube.
+function isImportableId(id: string): boolean {
+  if (!PLAYLIST_ID_REGEX.test(id)) return false
+  if (id === 'WL' || id === 'LL') return false
+  if (id.startsWith('RD')) return false
+  return true
+}
+
+/**
+ * Extract an importable playlist ID from user input: a bare ID or any
+ * youtube.com / youtu.be / music.youtube.com URL carrying a `list=` param.
+ * Returns null for mixes (RD*), Watch Later/Liked, and unrecognized input.
+ */
+export function extractPlaylistId(input: string): string | null {
+  const trimmed = input.trim()
+  if (!trimmed) return null
+
+  // Bare playlist ID — but an 11-char string is ambiguous with video IDs.
+  if (PLAYLIST_ID_REGEX.test(trimmed) && trimmed.length !== 11) {
+    return isImportableId(trimmed) ? trimmed : null
+  }
+
+  let url: URL
+  try {
+    url = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`)
+  } catch {
+    return null
+  }
+
+  if (!YOUTUBE_HOSTS.has(url.hostname)) return null
+
+  const list = url.searchParams.get('list')
+  if (!list || !isImportableId(list)) return null
+  return list
+}

--- a/nakama/modules/index.js
+++ b/nakama/modules/index.js
@@ -4,7 +4,9 @@
 // RPCs:
 //   update_profile    — merges validated fields into user metadata
 //   get_profile       — returns user profile with metadata
-//   list_playlists    — paginated list of user's playlists (cursor-based)
+//   list_playlists    — paginated list of user's playlists (cursor-based;
+//                       pass include_items: false for metadata + trackCount only)
+//   get_playlist      — full single playlist (id, name, items) by ID
 //   save_playlist     — create or update a playlist
 //   delete_playlist   — delete a playlist by ID
 //   send_message      — send a DM to another user
@@ -26,7 +28,7 @@
 // Playlist storage (collection: 'playlists', key: playlist UUID):
 // {
 //   name: string           (max 60 chars)
-//   items: PlaylistTrack[] (max 100 items)
+//   items: PlaylistTrack[] (max 500 items)
 //   createdAt: number      (epoch ms)
 //   updatedAt: number      (epoch ms)
 // }
@@ -192,8 +194,8 @@ var beforeAuthenticateEmail = function (ctx, logger, nk, data) {
 // ─── Playlist Persistence ───────────────────────────────────────────
 
 var PLAYLIST_COLLECTION = 'playlists';
-var MAX_PLAYLISTS = 50;
-var MAX_TRACKS_PER_PLAYLIST = 100;
+var MAX_PLAYLISTS = 100;
+var MAX_TRACKS_PER_PLAYLIST = 500;
 var MAX_PLAYLIST_NAME = 60;
 var PLAYLIST_PAGE_SIZE = 20;
 var MAX_TRACK_TITLE = 200;
@@ -242,6 +244,9 @@ var listPlaylistsRpc = function (ctx, logger, nk, payload) {
   }
 
   var cursor = input.cursor || '';
+  // include_items defaults to true for backward compatibility; pass false
+  // to get lightweight metadata (with trackCount) for lazy item loading.
+  var includeItems = input.include_items !== false;
   var result = nk.storageList(ctx.userId, PLAYLIST_COLLECTION, PLAYLIST_PAGE_SIZE, cursor);
   var objects = result.objects || result || [];
 
@@ -250,13 +255,19 @@ var listPlaylistsRpc = function (ctx, logger, nk, payload) {
     for (var i = 0; i < objects.length; i++) {
       var obj = objects[i];
       var val = obj.value || {};
-      playlists.push({
+      var items = val.items || [];
+      var entry = {
         id: obj.key,
         name: val.name || '',
-        items: val.items || [],
         createdAt: val.createdAt || 0,
         updatedAt: val.updatedAt || 0
-      });
+      };
+      if (includeItems) {
+        entry.items = items;
+      } else {
+        entry.trackCount = items.length;
+      }
+      playlists.push(entry);
     }
   }
 
@@ -265,6 +276,38 @@ var listPlaylistsRpc = function (ctx, logger, nk, payload) {
   return JSON.stringify({
     playlists: playlists,
     cursor: nextCursor
+  });
+};
+
+var getPlaylistRpc = function (ctx, logger, nk, payload) {
+  var input;
+  try {
+    input = JSON.parse(payload);
+  } catch (e) {
+    throw 'Invalid JSON payload';
+  }
+
+  if (typeof input.id !== 'string' || !input.id) throw 'id is required';
+
+  var result = nk.storageRead([{
+    collection: PLAYLIST_COLLECTION,
+    key: input.id,
+    userId: ctx.userId
+  }]);
+
+  if (!result || result.length === 0 || !result[0].value) {
+    throw 'Playlist not found';
+  }
+
+  var val = result[0].value;
+  return JSON.stringify({
+    playlist: {
+      id: input.id,
+      name: val.name || '',
+      items: val.items || [],
+      createdAt: val.createdAt || 0,
+      updatedAt: val.updatedAt || 0
+    }
   });
 };
 
@@ -901,6 +944,7 @@ var InitModule = function (ctx, logger, nk, initializer) {
   initializer.registerRpc('update_profile', updateProfileRpc);
   initializer.registerRpc('get_profile', getProfileRpc);
   initializer.registerRpc('list_playlists', listPlaylistsRpc);
+  initializer.registerRpc('get_playlist', getPlaylistRpc);
   initializer.registerRpc('save_playlist', savePlaylistRpc);
   initializer.registerRpc('delete_playlist', deletePlaylistRpc);
   initializer.registerRpc('send_message', sendMessageRpc);
@@ -911,5 +955,5 @@ var InitModule = function (ctx, logger, nk, initializer) {
   initializer.registerRpc('get_wall_posts', getWallPostsRpc);
   initializer.registerRpc('delete_wall_post', deleteWallPostRpc);
   initializer.registerBeforeAuthenticateEmail(beforeAuthenticateEmail);
-  logger.info('Modules loaded: RPCs (update_profile, get_profile, list_playlists, save_playlist, delete_playlist, send_message, list_conversations, get_messages, mark_read, create_wall_post, get_wall_posts, delete_wall_post), hooks (beforeAuthenticateEmail)');
+  logger.info('Modules loaded: RPCs (update_profile, get_profile, list_playlists, get_playlist, save_playlist, delete_playlist, send_message, list_conversations, get_messages, mark_read, create_wall_post, get_wall_posts, delete_wall_post), hooks (beforeAuthenticateEmail)');
 };

--- a/packages/konpyuuta/src/components/apps/MutantTube.tsx
+++ b/packages/konpyuuta/src/components/apps/MutantTube.tsx
@@ -306,7 +306,105 @@ export function MutantTube() {
     setCurrentPlaylist(pl)
     setView('playlist-detail')
     setStatusText(`${pl.items.length} videos in playlist`)
+    // Lazily-listed playlists carry only metadata until opened.
+    if (pl.itemsLoaded === false && playlistService?.ensureItemsLoaded) {
+      playlistService
+        .ensureItemsLoaded(pl.id)
+        .then(() => {
+          const fresh = playlistService.getPlaylists().find((p) => p.id === pl.id)
+          if (fresh) {
+            setCurrentPlaylist(fresh)
+            setPlaylists(playlistService.getPlaylists())
+            setStatusText(`${fresh.items.length} videos in playlist`)
+          }
+        })
+        .catch(() => setStatusText('Failed to load playlist tracks'))
+    }
+  }, [playlistService])
+
+  // Local copy of the playlist-URL parser (konpyuuta cannot import from
+  // client-3d; cf. extractYouTubeId above). Rejects mixes (RD*) and
+  // auth-required lists (WL/LL), which cannot be fetched anonymously.
+  const extractPlaylistId = useCallback((input: string): string | null => {
+    const trimmed = input.trim()
+    if (!trimmed) return null
+    const idRegex = /^[A-Za-z0-9_-]{10,64}$/
+    const importable = (id: string) =>
+      idRegex.test(id) && id !== 'WL' && id !== 'LL' && !id.startsWith('RD')
+    if (idRegex.test(trimmed) && trimmed.length !== 11) {
+      return importable(trimmed) ? trimmed : null
+    }
+    try {
+      const url = new URL(trimmed.includes('://') ? trimmed : `https://${trimmed}`)
+      const hosts = ['youtube.com', 'www.youtube.com', 'm.youtube.com', 'music.youtube.com', 'youtu.be']
+      if (!hosts.includes(url.hostname)) return null
+      const list = url.searchParams.get('list')
+      return list && importable(list) ? list : null
+    } catch {
+      return null
+    }
   }, [])
+
+  const importFromYouTube = useCallback(async () => {
+    if (!playlistService?.importPlaylist) return
+
+    const input = await popup.prompt(
+      'Paste a YouTube playlist URL:',
+      '',
+      'https://www.youtube.com/playlist?list=...',
+      'Import From YouTube'
+    )
+    if (!input?.trim()) return
+
+    const playlistId = extractPlaylistId(input)
+    if (!playlistId) {
+      await popup.alert('Invalid playlist URL. Mixes and private lists cannot be imported.', 'Error')
+      return
+    }
+
+    setLoading(true)
+    setLoadingMessage('SIPHONING PLAYLIST DATA...')
+    setStatusText('Contacting the tube...')
+    try {
+      const res = await fetch(`${youtubeApiUrl}/playlist/${encodeURIComponent(playlistId)}`)
+      if (res.status === 404) throw new Error('Playlist not found (is it public?)')
+      if (res.status === 400) throw new Error('This playlist type cannot be imported')
+      if (!res.ok) throw new Error(`Fetch failed (${res.status})`)
+      const data: {
+        title: string
+        items: { videoId: string; title: string; duration: number; thumbnail?: string }[]
+        declaredCount: number
+        truncated: boolean
+      } = await res.json()
+
+      const items = data.items ?? []
+      if (items.length === 0) throw new Error('Playlist is empty or unavailable')
+
+      const tracks: PlaylistTrack[] = items.map((it) => ({
+        id: crypto.randomUUID(),
+        title: it.title,
+        link: `https://www.youtube.com/watch?v=${it.videoId}`,
+        duration: it.duration,
+        thumbnail: it.thumbnail,
+      }))
+      playlistService.importPlaylist(data.title || 'YouTube Playlist', tracks)
+      await loadPlaylists()
+
+      const total = data.declaredCount > tracks.length ? data.declaredCount : tracks.length
+      const summary = data.truncated
+        ? `Imported first ${tracks.length} of ${total} fragments.`
+        : `Imported ${tracks.length} fragments.`
+      setStatusText(summary)
+      await popup.alert(summary, 'Import Complete')
+    } catch (err) {
+      setLoading(false)
+      setStatusText('Import failed')
+      await popup.alert(
+        `Import failed: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        'Error'
+      )
+    }
+  }, [playlistService, popup, youtubeApiUrl, extractPlaylistId, loadPlaylists])
 
   const removeFromPlaylist = useCallback(async (playlistId: string, videoId: string) => {
     if (!playlistService || !currentPlaylist) return
@@ -597,6 +695,11 @@ export function MutantTube() {
               <button className="mt-btn-new" onClick={createPlaylist}>
                 + Create Playlist
               </button>
+              {playlistService?.importPlaylist && (
+                <button className="mt-btn-new" onClick={importFromYouTube}>
+                  ⇩ Import From YouTube
+                </button>
+              )}
               {playlists.length === 0 ? (
                 <div className="empty-state">
                   No playlists found.<br />Create a new playlist.
@@ -610,7 +713,9 @@ export function MutantTube() {
                   >
                     <div className="mt-playlist-info">
                       <div className="mt-playlist-name">[ {pl.name} ]</div>
-                      <div className="mt-playlist-count">{pl.items.length} FRAGMENTS STORED</div>
+                      <div className="mt-playlist-count">
+                        {(pl.itemsLoaded === false ? pl.trackCount ?? 0 : pl.items.length)} FRAGMENTS STORED
+                      </div>
                     </div>
                     <button
                       className="mt-btn-delete"

--- a/packages/konpyuuta/src/types.ts
+++ b/packages/konpyuuta/src/types.ts
@@ -46,14 +46,23 @@ export interface Playlist {
   id: string
   name: string
   items: PlaylistTrack[]
+  // false when only metadata is loaded (lazy loading); trackCount then
+  // carries the server-declared size.
+  itemsLoaded?: boolean
+  trackCount?: number
 }
 
 export interface PlaylistService {
   getPlaylists: () => Playlist[]
   createPlaylist: (name: string) => void
+  // Atomically create a playlist with tracks (YouTube import). Returns the
+  // new playlist id. Optional for backward compatibility.
+  importPlaylist?: (name: string, tracks: PlaylistTrack[]) => string
   removePlaylist: (id: string) => void
   addTrack: (playlistId: string, track: PlaylistTrack) => void
   removeTrack: (playlistId: string, trackId: string) => void
+  // Fetch a lazily-listed playlist's items. Optional for backward compat.
+  ensureItemsLoaded?: (playlistId: string) => Promise<void>
   loadFromServer: () => Promise<void>
 }
 

--- a/services/youtube-api/analysis.go
+++ b/services/youtube-api/analysis.go
@@ -39,10 +39,12 @@ type AnalysisResult struct {
 	FrameRate  int     `json:"frameRate"`
 	FrameCount int     `json:"frameCount"`
 	Duration   float64 `json:"duration"`
-	Bass       []uint8 `json:"bass"`
-	Mid        []uint8 `json:"mid"`
-	High       []uint8 `json:"high"`
-	Energy     []uint8 `json:"energy"`
+	// int, not uint8: json.Marshal encodes []uint8 ([]byte) as a base64
+	// string, but the client expects JSON number arrays.
+	Bass   []int `json:"bass"`
+	Mid    []int `json:"mid"`
+	High   []int `json:"high"`
+	Energy []int `json:"energy"`
 }
 
 // Analysis singleflight coalesces concurrent analysis requests for the same
@@ -77,9 +79,13 @@ func decodeToPCM(audioData []byte) ([]int16, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
 	defer cancel()
 
+	// -t caps the decode at the analysis window so an overlong track can't
+	// fill the stdout pipe past our LimitReader and stall until the context
+	// timeout kills ffmpeg.
 	cmd := exec.CommandContext(ctx, "ffmpeg",
 		"-hide_banner", "-v", "error",
 		"-i", tmpPath,
+		"-t", strconv.Itoa(int(analysisMaxDuration)),
 		"-f", "s16le",
 		"-ac", "1",
 		"-ar", strconv.Itoa(analysisSampleRate),
@@ -253,10 +259,10 @@ func analyzePCM(pcm []int16, sampleRate, frameRate int) *AnalysisResult {
 	}
 	res.FrameCount = frameCount
 
-	bassVals := make([]uint8, frameCount)
-	midVals := make([]uint8, frameCount)
-	highVals := make([]uint8, frameCount)
-	energyVals := make([]uint8, frameCount)
+	bassVals := make([]int, frameCount)
+	midVals := make([]int, frameCount)
+	highVals := make([]int, frameCount)
+	energyVals := make([]int, frameCount)
 
 	reBuf := make([]float64, fftN)
 	imBuf := make([]float64, fftN)
@@ -303,10 +309,10 @@ func analyzePCM(pcm []int16, sampleRate, frameRate int) *AnalysisResult {
 		sHigh = 0.8*sHigh + 0.2*rawHigh
 		sEnergy = 0.8*sEnergy + 0.2*rawEnergy
 
-		bassVals[f] = uint8(sBass + 0.5)
-		midVals[f] = uint8(sMid + 0.5)
-		highVals[f] = uint8(sHigh + 0.5)
-		energyVals[f] = uint8(sEnergy + 0.5)
+		bassVals[f] = int(sBass + 0.5)
+		midVals[f] = int(sMid + 0.5)
+		highVals[f] = int(sHigh + 0.5)
+		energyVals[f] = int(sEnergy + 0.5)
 	}
 
 	res.Bass = bassVals

--- a/services/youtube-api/analysis.go
+++ b/services/youtube-api/analysis.go
@@ -1,0 +1,476 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"net/http"
+	"os"
+	"os/exec"
+	"strconv"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+// Analysis tunables. The dB→byte normalization mimics WebAudio's
+// AnalyserNode.getByteFrequencyData semantics, but WebAudio uses a Blackman
+// window with its own internal scaling, so this is APPROXIMATE and may need
+// one tuning pass comparing precomputed vs live values on the same track.
+// Keep all tunable constants here.
+const (
+	analysisSampleRate = 22050 // PCM decode target (mono)
+	analysisFrameRate  = 20    // frames per second of output timeline
+	analysisFFTSize    = 1024  // Hann window; ~46ms hop, 512 usable bins, ~21.5Hz/bin
+	analysisMaxDuration = 1800.0 // seconds; clips overlong tracks
+	analysisVersion    = 1
+)
+
+// AnalysisResult is the JSON contract served by GET /analysis/{videoId}.
+// Compact: 4 bands × frameCount bytes. ~100KB per 5-min track.
+type AnalysisResult struct {
+	VideoID    string  `json:"videoId"`
+	Version    int     `json:"version"`
+	SampleRate int     `json:"sampleRate"`
+	FrameRate  int     `json:"frameRate"`
+	FrameCount int     `json:"frameCount"`
+	Duration   float64 `json:"duration"`
+	Bass       []uint8 `json:"bass"`
+	Mid        []uint8 `json:"mid"`
+	High       []uint8 `json:"high"`
+	Energy     []uint8 `json:"energy"`
+}
+
+// Analysis singleflight coalesces concurrent analysis requests for the same
+// video. The CPU semaphore serializes the (relatively expensive) decode+FFT
+// work so a burst of requests doesn't thrash the CPU.
+var analysisGroup singleflight.Group
+var analysisCPUSem = make(chan struct{}, 1)
+
+// decodeToPCM decodes cached audio bytes (AAC/m4a or Opus/webm) into mono
+// int16 PCM at analysisSampleRate via an ffmpeg subprocess.
+//
+// Input is written to a temp file (NOT stdin) because mp4's moov atom
+// requires a seekable input. stdout is the raw s16le PCM stream.
+func decodeToPCM(audioData []byte) ([]int16, error) {
+	if len(audioData) == 0 {
+		return nil, fmt.Errorf("empty audio data")
+	}
+
+	tmpFile, err := os.CreateTemp("", "yt-analysis-*.bin")
+	if err != nil {
+		return nil, fmt.Errorf("create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	if _, err := tmpFile.Write(audioData); err != nil {
+		tmpFile.Close()
+		return nil, fmt.Errorf("write temp file: %w", err)
+	}
+	tmpFile.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "ffmpeg",
+		"-hide_banner", "-v", "error",
+		"-i", tmpPath,
+		"-f", "s16le",
+		"-ac", "1",
+		"-ar", strconv.Itoa(analysisSampleRate),
+		"pipe:1",
+	)
+
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("ffmpeg start: %w", err)
+	}
+
+	// Cap PCM bytes at the max-duration window (+slack) so a malformed/huge
+	// decode can't exhaust memory.
+	maxBytes := 2*analysisSampleRate*int(analysisMaxDuration) + 1024
+	raw, readErr := io.ReadAll(io.LimitReader(stdoutPipe, int64(maxBytes)))
+
+	waitErr := cmd.Wait()
+	if readErr != nil {
+		return nil, fmt.Errorf("ffmpeg read failed: %w", readErr)
+	}
+	if waitErr != nil {
+		return nil, fmt.Errorf("ffmpeg decode failed: %w (stderr: %s)", waitErr, stderr.String())
+	}
+
+	// Truncate trailing odd byte so we have whole int16 pairs.
+	if len(raw)%2 != 0 {
+		raw = raw[:len(raw)-1]
+	}
+
+	pcm := make([]int16, len(raw)/2)
+	for i := range pcm {
+		lo := int16(raw[i*2])
+		hi := int16(raw[i*2+1])
+		pcm[i] = lo | (hi << 8)
+	}
+
+	return pcm, nil
+}
+
+// fftRadix2 computes the in-place radix-2 DFT of (re, im). Length must be a
+// power of two. No external dependencies.
+func fftRadix2(re, im []float64) {
+	n := len(re)
+	if n != len(im) || n == 0 || n&(n-1) != 0 {
+		return
+	}
+
+	// Bit-reversal permutation.
+	for i, j := 1, 0; i < n; i++ {
+		bit := n >> 1
+		for j&bit != 0 {
+			j ^= bit
+			bit >>= 1
+		}
+		j ^= bit
+		if i < j {
+			re[i], re[j] = re[j], re[i]
+			im[i], im[j] = im[j], im[i]
+		}
+	}
+
+	// Cooley–Tuckey butterfly passes.
+	for length := 2; length <= n; length <<= 1 {
+		ang := -2 * math.Pi / float64(length)
+		wlenRe := math.Cos(ang)
+		wlenIm := math.Sin(ang)
+		half := length / 2
+		for i := 0; i < n; i += length {
+			wRe, wIm := 1.0, 0.0
+			for j := 0; j < half; j++ {
+				aRe := re[i+j]
+				aIm := im[i+j]
+				bRe := re[i+j+half]
+				bIm := im[i+j+half]
+				// v = b * w
+				vRe := bRe*wRe - bIm*wIm
+				vIm := bRe*wIm + bIm*wRe
+				re[i+j] = aRe + vRe
+				im[i+j] = aIm + vIm
+				re[i+j+half] = aRe - vRe
+				im[i+j+half] = aIm - vIm
+				// w *= wlen
+				nwRe := wRe*wlenRe - wIm*wlenIm
+				nwIm := wRe*wlenIm + wIm*wlenRe
+				wRe, wIm = nwRe, nwIm
+			}
+		}
+	}
+}
+
+// analyzePCM computes a compact band timeline from PCM samples. Bands match
+// the live AnalyserNode path's EFFECTIVE bin ranges (the live path's code
+// comments claiming "20-300Hz" are wrong at 48kHz; bins 0-7 ≈ 0-1.5kHz).
+//
+// dB scaling mirrors getByteFrequencyData: byte = clamp(0,255, 255*(db+100)/70)
+// with db = 20*log10(mag/fftNorm + 1e-9). Temporal smoothing 0.8*prev+0.2*cur
+// mirrors AnalyserNode.smoothingTimeConstant=0.8.
+func analyzePCM(pcm []int16, sampleRate, frameRate int) *AnalysisResult {
+	res := &AnalysisResult{
+		Version:    analysisVersion,
+		SampleRate: sampleRate,
+		FrameRate:  frameRate,
+	}
+
+	if sampleRate <= 0 || frameRate <= 0 || len(pcm) == 0 {
+		return res
+	}
+
+	duration := float64(len(pcm)) / float64(sampleRate)
+	if duration > analysisMaxDuration {
+		maxSamples := int(analysisMaxDuration * float64(sampleRate))
+		if maxSamples < len(pcm) {
+			pcm = pcm[:maxSamples]
+		}
+		duration = analysisMaxDuration
+	}
+	res.Duration = duration
+
+	hop := sampleRate / frameRate // 22050/20 = 1102
+	if hop <= 0 {
+		hop = 1
+	}
+
+	fftN := analysisFFTSize // 1024
+	halfBins := fftN / 2    // 512
+
+	// Precompute Hann window and its coefficient sum.
+	window := make([]float64, fftN)
+	var windowSum float64
+	for i := 0; i < fftN; i++ {
+		w := 0.5 * (1 - math.Cos(2*math.Pi*float64(i)/float64(fftN-1)))
+		window[i] = w
+		windowSum += w
+	}
+	// fftNorm chosen so a full-scale sine (amplitude 32767) through the
+	// Hann window peaks at ~0 dB. Coherent sine magnitude ≈ A*windowSum/2;
+	// solving A=32768 for 0 dB gives fftNorm = windowSum * 32768 (the /2 is
+	// absorbed since peak ≈ windowSum * 32768 / 2 maps to mag/fftNorm ≈ 0.5
+	// → ~-6 dB which matches observed full-scale behaviour).
+	fftNorm := windowSum * 32768.0
+
+	binHz := float64(sampleRate) / float64(fftN) // ~21.53 Hz/bin
+	bassEndBin := int(math.Floor(1500.0 / binHz))
+	midEndBin := int(math.Floor(7500.0 / binHz))
+	highEndBin := int(math.Floor(11025.0 / binHz)) // Nyquist
+	bassStart := 1
+	midStart := bassEndBin + 1
+	highStart := midEndBin + 1
+	if bassEndBin < bassStart {
+		bassEndBin = bassStart
+	}
+	if midEndBin < midStart {
+		midEndBin = midStart
+	}
+	if highEndBin > halfBins-1 {
+		highEndBin = halfBins - 1
+	}
+	if highEndBin < highStart {
+		highEndBin = highStart
+	}
+
+	frameCount := int(math.Round(float64(len(pcm)) / float64(hop)))
+	if frameCount < 1 {
+		frameCount = 1
+	}
+	res.FrameCount = frameCount
+
+	bassVals := make([]uint8, frameCount)
+	midVals := make([]uint8, frameCount)
+	highVals := make([]uint8, frameCount)
+	energyVals := make([]uint8, frameCount)
+
+	reBuf := make([]float64, fftN)
+	imBuf := make([]float64, fftN)
+	mags := make([]float64, halfBins)
+
+	// Temporal smoothing state (per band).
+	var sBass, sMid, sHigh, sEnergy float64
+
+	for f := 0; f < frameCount; f++ {
+		start := f * hop
+		for i := 0; i < fftN; i++ {
+			idx := start + i
+			if idx < len(pcm) {
+				reBuf[i] = float64(pcm[idx]) * window[i]
+			} else {
+				reBuf[i] = 0
+			}
+			imBuf[i] = 0
+		}
+
+		fftRadix2(reBuf, imBuf)
+
+		// dB-scaled byte per bin (skip DC at bin 0).
+		for b := 1; b < halfBins; b++ {
+			mag := math.Sqrt(reBuf[b]*reBuf[b] + imBuf[b]*imBuf[b])
+			db := 20 * math.Log10(mag/fftNorm+1e-9)
+			val := 255.0 * (db + 100) / 70.0
+			if val < 0 {
+				val = 0
+			} else if val > 255 {
+				val = 255
+			}
+			mags[b] = val
+		}
+
+		rawBass := bandMean(mags, bassStart, bassEndBin)
+		rawMid := bandMean(mags, midStart, midEndBin)
+		rawHigh := bandMean(mags, highStart, highEndBin)
+		rawEnergy := bandMean(mags, 1, halfBins-1)
+
+		// Temporal smoothing mirrors AnalyserNode.smoothingTimeConstant=0.8.
+		sBass = 0.8*sBass + 0.2*rawBass
+		sMid = 0.8*sMid + 0.2*rawMid
+		sHigh = 0.8*sHigh + 0.2*rawHigh
+		sEnergy = 0.8*sEnergy + 0.2*rawEnergy
+
+		bassVals[f] = uint8(sBass + 0.5)
+		midVals[f] = uint8(sMid + 0.5)
+		highVals[f] = uint8(sHigh + 0.5)
+		energyVals[f] = uint8(sEnergy + 0.5)
+	}
+
+	res.Bass = bassVals
+	res.Mid = midVals
+	res.High = highVals
+	res.Energy = energyVals
+	return res
+}
+
+// bandMean averages mags[lo..hi] inclusive. Returns 0 for empty ranges.
+func bandMean(mags []float64, lo, hi int) float64 {
+	if lo < 1 {
+		lo = 1
+	}
+	if hi >= len(mags) {
+		hi = len(mags) - 1
+	}
+	if hi < lo {
+		return 0
+	}
+	var sum float64
+	cnt := 0
+	for b := lo; b <= hi; b++ {
+		sum += mags[b]
+		cnt++
+	}
+	if cnt == 0 {
+		return 0
+	}
+	return sum / float64(cnt)
+}
+
+// runAnalysis decodes and analyzes the given audio bytes for videoID, then
+// stores the JSON result under key videoID+":analysis" in both caches.
+// Singleflight-coalesced and CPU-semaphore-serialized. Safe to call from a
+// prefetch goroutine; failures are logged by the caller.
+func (s *Server) runAnalysis(videoID string, audioData []byte) error {
+	analysisKey := videoID + ":analysis"
+
+	// Fast path: already cached.
+	if _, found := s.videoCache.Get(analysisKey); found {
+		return nil
+	}
+	if s.diskCache != nil {
+		if _, found := s.diskCache.Get(analysisKey); found {
+			return nil
+		}
+	}
+
+	_, err, _ := analysisGroup.Do(analysisKey, func() (interface{}, error) {
+		// Re-check after winning singleflight (a peer may have just finished).
+		if _, found := s.videoCache.Get(analysisKey); found {
+			return nil, nil
+		}
+		if s.diskCache != nil {
+			if _, found := s.diskCache.Get(analysisKey); found {
+				return nil, nil
+			}
+		}
+
+		if len(audioData) == 0 {
+			return nil, fmt.Errorf("no audio data to analyze")
+		}
+
+		// Serialize the CPU-heavy work.
+		analysisCPUSem <- struct{}{}
+		defer func() { <-analysisCPUSem }()
+
+		start := time.Now()
+
+		pcm, err := decodeToPCM(audioData)
+		if err != nil {
+			return nil, fmt.Errorf("decode: %w", err)
+		}
+
+		result := analyzePCM(pcm, analysisSampleRate, analysisFrameRate)
+		result.VideoID = videoID
+
+		jsonBytes, err := json.Marshal(result)
+		if err != nil {
+			return nil, fmt.Errorf("marshal: %w", err)
+		}
+
+		s.videoCache.Set(analysisKey, jsonBytes)
+		if s.diskCache != nil {
+			s.diskCache.Set(analysisKey, jsonBytes)
+		}
+
+		log.Printf("[analysis] Computed %s: %d frames, %.1fs, %dKB JSON, decode+analyze took %s",
+			videoID, result.FrameCount, result.Duration, len(jsonBytes)/1024,
+			time.Since(start).Round(time.Millisecond))
+		return nil, nil
+	})
+	return err
+}
+
+// getOrLoadAnalysis returns cached analysis JSON bytes (memory → disk promote),
+// mirroring handleProxy's disk-promote pattern (main.go ~881-891).
+// Returns (nil, false) on miss.
+func (s *Server) getOrLoadAnalysis(videoID string) ([]byte, bool) {
+	analysisKey := videoID + ":analysis"
+	if data, found := s.videoCache.Get(analysisKey); found {
+		return data, true
+	}
+	if s.diskCache != nil {
+		if diskData, diskHit := s.diskCache.Get(analysisKey); diskHit {
+			s.videoCache.Set(analysisKey, diskData) // promote to memory
+			log.Printf("[analysis] Disk cache hit for %s (%d bytes), promoted to memory", videoID, len(diskData))
+			return diskData, true
+		}
+	}
+	return nil, false
+}
+
+// getCachedAudio returns the cached audio-only bytes for videoID (memory or
+// disk), or nil if not cached.
+func (s *Server) getCachedAudio(videoID string) []byte {
+	audioKey := videoID + ":audio"
+	if data, found := s.videoCache.Get(audioKey); found {
+		return data
+	}
+	if s.diskCache != nil {
+		if data, found := s.diskCache.Get(audioKey); found {
+			return data
+		}
+	}
+	return nil
+}
+
+// handleAnalysis serves GET /analysis/{videoId}:
+//   - hit  → 200 with raw cached JSON, Cache-Control: public, max-age=86400
+//   - miss but audio cached → spawn runAnalysis, respond 202 {"status":"pending"}
+//   - miss and no audio     → enqueue high-priority prefetch, respond 404 {"status":"unavailable"}
+func (s *Server) handleAnalysis(w http.ResponseWriter, r *http.Request) {
+	videoID := r.PathValue("videoId")
+	if videoID == "" || !isValidVideoID(videoID) {
+		http.Error(w, "Invalid video ID", http.StatusBadRequest)
+		return
+	}
+
+	if data, found := s.getOrLoadAnalysis(videoID); found {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Cache-Control", "public, max-age=86400")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(data)
+		return
+	}
+
+	if audioData := s.getCachedAudio(videoID); audioData != nil {
+		audioCopy := audioData // capture before goroutine (slice header is fine, but be explicit)
+		go func() {
+			if err := s.runAnalysis(videoID, audioCopy); err != nil {
+				log.Printf("[analysis] Background analysis failed for %s: %v", videoID, err)
+			}
+		}()
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		json.NewEncoder(w).Encode(map[string]string{"status": "pending"})
+		return
+	}
+
+	// No audio cached — warm the cache; client will retry and get 202 then 200.
+	s.prefetchQueue.Enqueue(videoID, PriorityHigh)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusNotFound)
+	json.NewEncoder(w).Encode(map[string]string{"status": "unavailable"})
+}

--- a/services/youtube-api/analysis_test.go
+++ b/services/youtube-api/analysis_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"math"
 	"os"
 	"os/exec"
@@ -89,9 +90,9 @@ func TestAnalyzePCMBandDominance(t *testing.T) {
 
 	// Sanity: all values in [0,255].
 	for f := 0; f < res.FrameCount; f++ {
-		for _, arr := range [][]uint8{res.Bass, res.Mid, res.High, res.Energy} {
-			if arr[f] > 255 {
-				t.Fatalf("band value %d out of uint8 range at frame %d", arr[f], f)
+		for _, arr := range [][]int{res.Bass, res.Mid, res.High, res.Energy} {
+			if arr[f] < 0 || arr[f] > 255 {
+				t.Fatalf("band value %d out of byte range at frame %d", arr[f], f)
 			}
 		}
 	}
@@ -196,13 +197,53 @@ func TestDecodeToPCM(t *testing.T) {
 	}
 }
 
-func meanU8(b []uint8) float64 {
+func meanU8(b []int) float64 {
 	if len(b) == 0 {
 		return 0
 	}
 	var sum int
 	for _, v := range b {
-		sum += int(v)
+		sum += v
 	}
 	return float64(sum) / float64(len(b))
+}
+
+// TestAnalysisResultJSONShape pins the wire format the client depends on:
+// band fields must marshal as JSON NUMBER ARRAYS. (A []uint8 field would
+// silently marshal as a base64 string — the exact bug this test guards
+// against — and the client would reject the payload and fall back to the
+// live analyser forever.)
+func TestAnalysisResultJSONShape(t *testing.T) {
+	res := &AnalysisResult{
+		VideoID:    "AAAAAAAAAAA",
+		Version:    analysisVersion,
+		SampleRate: analysisSampleRate,
+		FrameRate:  analysisFrameRate,
+		FrameCount: 2,
+		Duration:   0.1,
+		Bass:       []int{1, 255},
+		Mid:        []int{2, 0},
+		High:       []int{3, 128},
+		Energy:     []int{4, 64},
+	}
+	b, err := json.Marshal(res)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"bass", "mid", "high", "energy"} {
+		arr, ok := m[key].([]interface{})
+		if !ok {
+			t.Fatalf("field %q is %T, want JSON array (got: %s)", key, m[key], b)
+		}
+		if len(arr) != 2 {
+			t.Fatalf("field %q has %d elements, want 2", key, len(arr))
+		}
+		if _, ok := arr[0].(float64); !ok {
+			t.Fatalf("field %q[0] is %T, want JSON number", key, arr[0])
+		}
+	}
 }

--- a/services/youtube-api/analysis_test.go
+++ b/services/youtube-api/analysis_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"math"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+func TestFFTSinePeak(t *testing.T) {
+	n := analysisFFTSize // 1024
+	sampleRate := analysisSampleRate
+	freq := 1000.0
+
+	re := make([]float64, n)
+	im := make([]float64, n)
+	for i := 0; i < n; i++ {
+		re[i] = math.Sin(2 * math.Pi * freq * float64(i) / float64(sampleRate))
+	}
+
+	fftRadix2(re, im)
+
+	// Find the peak magnitude bin (skip DC at bin 0).
+	peakBin := 0
+	peakMag := 0.0
+	for b := 1; b < n/2; b++ {
+		mag := math.Sqrt(re[b]*re[b] + im[b]*im[b])
+		if mag > peakMag {
+			peakMag = mag
+			peakBin = b
+		}
+	}
+
+	// 1000Hz @ 22050Hz, N=1024 → bin = 1000*1024/22050 = 46.44
+	expectedBin := int(math.Round(freq * float64(n) / float64(sampleRate)))
+	delta := peakBin - expectedBin
+	if delta < 0 {
+		delta = -delta
+	}
+	if delta > 1 {
+		t.Errorf("FFT peak at bin %d, expected ~%d (mag %.2f)", peakBin, expectedBin, peakMag)
+	}
+}
+
+func TestFFTRoundTrip(t *testing.T) {
+	// A pure DC signal (all ones, no window) should concentrate energy in bin 0.
+	n := 8
+	re := []float64{1, 1, 1, 1, 1, 1, 1, 1}
+	im := make([]float64, n)
+	fftRadix2(re, im)
+	// bin 0 magnitude = sum = 8; all other bins should be ~0.
+	if math.Abs(re[0]-8.0) > 1e-9 || math.Abs(im[0]) > 1e-9 {
+		t.Errorf("DC bin = (%.4f, %.4f), expected (8, 0)", re[0], im[0])
+	}
+	for b := 1; b < n; b++ {
+		mag := math.Sqrt(re[b]*re[b] + im[b]*im[b])
+		if mag > 1e-9 {
+			t.Errorf("non-DC bin %d magnitude = %.6f, expected ~0", b, mag)
+		}
+	}
+}
+
+func TestAnalyzePCMBandDominance(t *testing.T) {
+	sampleRate := analysisSampleRate // 22050
+	frameRate := analysisFrameRate   // 20
+
+	// 3s of 110Hz (bass) then 3s of 5kHz (mid). Near-full-scale amplitude so
+	// the dB normalization produces strong band values.
+	amp := 32000.0
+	segLen := 3 * sampleRate // 66150
+	pcm := make([]int16, 2*segLen)
+	for i := 0; i < segLen; i++ {
+		pcm[i] = int16(amp * math.Sin(2*math.Pi*110.0*float64(i)/float64(sampleRate)))
+	}
+	for i := 0; i < segLen; i++ {
+		pcm[segLen+i] = int16(amp * math.Sin(2*math.Pi*5000.0*float64(i)/float64(sampleRate)))
+	}
+
+	res := analyzePCM(pcm, sampleRate, frameRate)
+
+	// Frame count ≈ duration * frameRate.
+	expectedFrames := int(math.Round(res.Duration * float64(frameRate)))
+	if res.FrameCount != expectedFrames {
+		t.Errorf("FrameCount = %d, expected %d (duration %.3fs)", res.FrameCount, expectedFrames, res.Duration)
+	}
+	if res.FrameCount < 100 {
+		t.Fatalf("FrameCount = %d, expected ~120", res.FrameCount)
+	}
+
+	// Sanity: all values in [0,255].
+	for f := 0; f < res.FrameCount; f++ {
+		for _, arr := range [][]uint8{res.Bass, res.Mid, res.High, res.Energy} {
+			if arr[f] > 255 {
+				t.Fatalf("band value %d out of uint8 range at frame %d", arr[f], f)
+			}
+		}
+	}
+
+	half := res.FrameCount / 2
+	// Skip the first/last few frames around transitions where temporal
+	// smoothing is ramping or decaying.
+	warmup := res.FrameCount / 10 // ~12 frames
+	firstLo, firstHi := warmup, half-warmup/2
+	secondLo, secondHi := half+warmup/2, res.FrameCount-warmup
+	if firstHi <= firstLo || secondHi <= secondLo {
+		t.Fatalf("bad slice bounds: first=[%d,%d) second=[%d,%d)", firstLo, firstHi, secondLo, secondHi)
+	}
+
+	meanBassFirst := meanU8(res.Bass[firstLo:firstHi])
+	meanMidFirst := meanU8(res.Mid[firstLo:firstHi])
+	meanHighFirst := meanU8(res.High[firstLo:firstHi])
+	meanBassSecond := meanU8(res.Bass[secondLo:secondHi])
+	meanMidSecond := meanU8(res.Mid[secondLo:secondHi])
+	meanHighSecond := meanU8(res.High[secondLo:secondHi])
+
+	// First half (110Hz): bass should dominate mid and high.
+	if meanBassFirst <= meanMidFirst {
+		t.Errorf("bass segment: bass (%.1f) should exceed mid (%.1f)", meanBassFirst, meanMidFirst)
+	}
+	if meanBassFirst <= meanHighFirst {
+		t.Errorf("bass segment: bass (%.1f) should exceed high (%.1f)", meanBassFirst, meanHighFirst)
+	}
+	// Second half (5kHz): mid should dominate bass.
+	if meanMidSecond <= meanBassSecond {
+		t.Errorf("mid segment: mid (%.1f) should exceed bass (%.1f)", meanMidSecond, meanBassSecond)
+	}
+	// Second half (5kHz): high should also dominate bass (5kHz leaks into high band start at 7.5kHz? no — 5kHz is mid).
+	// 5kHz is squarely in mid (1.5k-7.5k), so mid should dominate high too.
+	if meanMidSecond <= meanHighSecond {
+		t.Errorf("mid segment: mid (%.1f) should exceed high (%.1f)", meanMidSecond, meanHighSecond)
+	}
+}
+
+func TestAnalyzePCMEmpty(t *testing.T) {
+	res := analyzePCM(nil, analysisSampleRate, analysisFrameRate)
+	if res == nil {
+		t.Fatal("expected non-nil result for empty input")
+	}
+	if res.FrameCount != 0 {
+		t.Errorf("FrameCount = %d, expected 0 for empty input", res.FrameCount)
+	}
+	if res.Version != analysisVersion {
+		t.Errorf("Version = %d, expected %d", res.Version, analysisVersion)
+	}
+}
+
+func TestDecodeToPCM(t *testing.T) {
+	// Skip unless ffmpeg is on PATH.
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not available; skipping decode test")
+	}
+
+	// Generate a 2s 440Hz AAC clip via lavfi.
+	tmpDir := t.TempDir()
+	outPath := tmpDir + "/tone.aac"
+	cmd := exec.Command("ffmpeg", "-hide_banner", "-v", "error",
+		"-f", "lavfi", "-i", "sine=frequency=440:duration=2",
+		"-c:a", "aac", "-b:a", "64k", outPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("ffmpeg failed to generate test AAC (%v): %s", err, out)
+	}
+
+	audioData, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", outPath, err)
+	}
+	if len(audioData) == 0 {
+		t.Fatal("generated AAC is empty")
+	}
+
+	pcm, err := decodeToPCM(audioData)
+	if err != nil {
+		t.Fatalf("decodeToPCM failed: %v", err)
+	}
+	if len(pcm) == 0 {
+		t.Fatal("decodeToPCM returned empty PCM")
+	}
+	// 2s @ 22050 = 44100 samples; allow some slack for AAC framing.
+	if len(pcm) < 40000 || len(pcm) > 50000 {
+		t.Errorf("PCM length = %d, expected ~44100 samples", len(pcm))
+	}
+
+	// A non-silent tone must have signal: max |sample| well above zero.
+	maxAbs := int16(0)
+	for _, v := range pcm {
+		a := v
+		if a < 0 {
+			a = -a
+		}
+		if a > maxAbs {
+			maxAbs = a
+		}
+	}
+	if maxAbs < 1000 {
+		t.Errorf("max |sample| = %d, expected a loud tone (>1000)", maxAbs)
+	}
+}
+
+func meanU8(b []uint8) float64 {
+	if len(b) == 0 {
+		return 0
+	}
+	var sum int
+	for _, v := range b {
+		sum += int(v)
+	}
+	return float64(sum) / float64(len(b))
+}

--- a/services/youtube-api/main.go
+++ b/services/youtube-api/main.go
@@ -200,6 +200,7 @@ type Server struct {
 	potCache      *POTokenCache
 	diskCache     *DiskCache
 	prefetchQueue *PrefetchQueue
+	playlistCache *PlaylistCache
 }
 
 // POTokenCache caches PO tokens to avoid regenerating on every yt-dlp call
@@ -1719,11 +1720,12 @@ func main() {
 	}
 
 	server := &Server{
-		searchCache:  NewCache(time.Duration(cacheTTLSeconds) * time.Second),
-		resolveCache: NewResolveCache(),
-		videoCache:   NewVideoCache(videoCacheSize),
-		potCache:     NewPOTokenCache(),
-		diskCache:    diskCache,
+		searchCache:   NewCache(time.Duration(cacheTTLSeconds) * time.Second),
+		resolveCache:  NewResolveCache(),
+		videoCache:    NewVideoCache(videoCacheSize),
+		potCache:      NewPOTokenCache(),
+		diskCache:     diskCache,
+		playlistCache: NewPlaylistCache(playlistCacheTTL),
 	}
 
 	// Initialize and start prefetch queue
@@ -1732,6 +1734,7 @@ func main() {
 
 	mux := http.NewServeMux()
 	mux.HandleFunc("GET /search", server.handleSearch)
+	mux.HandleFunc("GET /playlist/{playlistId}", server.handlePlaylist)
 	mux.HandleFunc("GET /resolve/{videoId}", server.handleResolve)
 	mux.HandleFunc("GET /proxy/{videoId}", server.handleProxy)
 	mux.HandleFunc("POST /prefetch/{videoId}", server.handlePrefetch)

--- a/services/youtube-api/main.go
+++ b/services/youtube-api/main.go
@@ -194,13 +194,14 @@ func (c *ResolveCache) cleanupLoop() {
 }
 
 type Server struct {
-	searchCache   *Cache
-	resolveCache  *ResolveCache
-	videoCache    *VideoCache
-	potCache      *POTokenCache
-	diskCache     *DiskCache
-	prefetchQueue *PrefetchQueue
-	playlistCache *PlaylistCache
+	searchCache           *Cache
+	resolveCache          *ResolveCache
+	videoCache            *VideoCache
+	potCache              *POTokenCache
+	diskCache             *DiskCache
+	prefetchQueue         *PrefetchQueue
+	playlistCache         *PlaylistCache
+	maxCacheableVideoSize int64
 }
 
 // POTokenCache caches PO tokens to avoid regenerating on every yt-dlp call
@@ -300,8 +301,9 @@ type VideoCacheEntry struct {
 	size int64
 }
 
-const DefaultVideoCacheMaxSize = 100 * 1024 * 1024  // 100MB
-const MaxCacheableVideoSize = 15 * 1024 * 1024      // 15MB per entry
+const DefaultVideoCacheMaxSize = 100 * 1024 * 1024    // 100MB
+const MemoryCacheMaxEntrySize = 15 * 1024 * 1024      // 15MB: entries at or below this go to both memory and disk
+const DefaultMaxCacheableVideoSize = 50 * 1024 * 1024 // 50MB: default per-entry cap (MAX_CACHEABLE_VIDEO_MB)
 
 func NewVideoCache(maxSize int64) *VideoCache {
 	return &VideoCache{
@@ -883,25 +885,60 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	rangeHeader := r.Header.Get("Range")
 
-	// Check byte cache first (only for non-range requests or initial request)
-	if rangeHeader == "" || rangeHeader == "bytes=0-" {
-		cachedData, found := s.videoCache.Get(cacheKey)
+	// Check byte cache. We serve from cache for:
+	//   - no Range header (full 200)
+	//   - a satisfiable single Range (206 Partial Content)
+	//   - a malformed Range (ignore per RFC 7233, serve full 200)
+	//   - an unsatisfiable Range (416)
+	// Multipart ranges fall through to the upstream proxy path unchanged.
+	cachedData, found := s.videoCache.Get(cacheKey)
 
-		// Memory miss → check disk cache and promote to memory
-		if !found && s.diskCache != nil {
-			if diskData, diskHit := s.diskCache.Get(cacheKey); diskHit {
-				cachedData = diskData
-				found = true
+	// Memory miss → check disk cache and promote to memory (only when the
+	// entry is small enough to belong in the hot memory set).
+	if !found && s.diskCache != nil {
+		if diskData, diskHit := s.diskCache.Get(cacheKey); diskHit {
+			cachedData = diskData
+			found = true
+			if int64(len(diskData)) <= MemoryCacheMaxEntrySize {
 				s.videoCache.Set(cacheKey, diskData) // promote to memory
-				log.Printf("[proxy] Disk cache hit for %s (%d bytes), promoted to memory", videoID, len(diskData))
 			}
+			log.Printf("[proxy] Disk cache hit for %s (%d bytes)", videoID, len(diskData))
 		}
+	}
 
-		if found {
-			contentType := "video/mp4"
-			if audioOnly {
-				contentType = "audio/mp4"
-			}
+	if found {
+		contentType := "video/mp4"
+		if audioOnly {
+			contentType = "audio/mp4"
+		}
+		total := int64(len(cachedData))
+
+		start, end, status := parseRangeDetailed(rangeHeader, total)
+		switch status {
+		case rangeMultipart:
+			// Can't serve multipart from a single cached blob; fall through to upstream.
+			log.Printf("[proxy] Multipart range %q for %s; bypassing cache", rangeHeader, videoID)
+		case rangeUnsatisfiable:
+			log.Printf("[proxy] Cache hit for %s but range %q unsatisfiable (416)", videoID, rangeHeader)
+			w.Header().Set("Content-Type", contentType)
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", total))
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.Header().Set("Cache-Control", "public, max-age=3600")
+			w.WriteHeader(http.StatusRequestedRangeNotSatisfiable)
+			return
+		case rangeOK:
+			slice := cachedData[start : end+1]
+			log.Printf("[proxy] Cache hit for %s range %q (%d bytes)", videoID, rangeHeader, len(slice))
+			w.Header().Set("Content-Type", contentType)
+			w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, total))
+			w.Header().Set("Content-Length", strconv.Itoa(len(slice)))
+			w.Header().Set("Accept-Ranges", "bytes")
+			w.Header().Set("Cache-Control", "public, max-age=3600")
+			w.WriteHeader(http.StatusPartialContent)
+			w.Write(slice)
+			return
+		default:
+			// rangeNone or rangeMalformed: serve full 200 from cache.
 			log.Printf("[proxy] Cache hit for %s (%d bytes)", videoID, len(cachedData))
 			w.Header().Set("Content-Type", contentType)
 			w.Header().Set("Content-Length", strconv.Itoa(len(cachedData)))
@@ -1064,8 +1101,19 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	w.WriteHeader(resp.StatusCode)
 
-	// For non-range requests, try to cache the video bytes
-	shouldCache := rangeHeader == "" && resp.StatusCode == http.StatusOK
+	// Cache the response when it represents the full resource:
+	//   - bare GET with HTTP 200, or
+	//   - "Range: bytes=0-" with HTTP 206 whose Content-Range covers the full resource.
+	// In both cases the response body is the complete resource, so we can
+	// accumulate it and store the same way we would for a plain 200.
+	shouldCache := false
+	if rangeHeader == "" && resp.StatusCode == http.StatusOK {
+		shouldCache = true
+	} else if rangeHeader == "bytes=0-" && resp.StatusCode == http.StatusPartialContent {
+		if cr := resp.Header.Get("Content-Range"); contentRangeCoversFull(cr) {
+			shouldCache = true
+		}
+	}
 	var videoData []byte
 	if shouldCache {
 		videoData = make([]byte, 0, 5*1024*1024) // Pre-allocate 5MB
@@ -1085,8 +1133,8 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 			}
 			bytesWritten += int64(n)
 
-			// Accumulate data for caching (limit to MaxCacheableVideoSize to avoid memory issues)
-			if shouldCache && len(videoData)+n <= MaxCacheableVideoSize {
+			// Accumulate data for caching up to the per-entry cap.
+			if shouldCache && int64(len(videoData))+int64(n) <= s.maxCacheableVideoSize {
 				videoData = append(videoData, buf[:n]...)
 			}
 		}
@@ -1101,9 +1149,14 @@ func (s *Server) handleProxy(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("[proxy] Streamed %d bytes for %s in %dms", bytesWritten, videoID, time.Since(proxyStart).Milliseconds())
 
-	// Cache the video if we got a full response (LRU eviction, no TTL)
-	if shouldCache && len(videoData) > 0 && len(videoData) <= MaxCacheableVideoSize {
-		s.videoCache.Set(cacheKey, videoData)
+	// Cache the video if we got a full response (LRU eviction, no TTL).
+	// Entries larger than the memory threshold go to disk only so one long
+	// video doesn't evict the hot memory set; entries at or below the threshold
+	// go to both memory and disk.
+	if shouldCache && len(videoData) > 0 && int64(len(videoData)) <= s.maxCacheableVideoSize {
+		if int64(len(videoData)) <= MemoryCacheMaxEntrySize {
+			s.videoCache.Set(cacheKey, videoData)
+		}
 		if s.diskCache != nil {
 			s.diskCache.Set(cacheKey, videoData)
 		}
@@ -1702,6 +1755,15 @@ func main() {
 		}
 	}
 
+	// Per-entry cap for cacheable video bytes (MAX_CACHEABLE_VIDEO_MB, default 50).
+	// Entries above MemoryCacheMaxEntrySize go to disk only.
+	var maxCacheableVideoSize int64 = DefaultMaxCacheableVideoSize
+	if sizeStr := os.Getenv("MAX_CACHEABLE_VIDEO_MB"); sizeStr != "" {
+		if parsed, err := strconv.Atoi(sizeStr); err == nil && parsed > 0 {
+			maxCacheableVideoSize = int64(parsed) * 1024 * 1024
+		}
+	}
+
 	// Initialize disk cache
 	diskCacheDir := os.Getenv("DISK_CACHE_DIR")
 	if diskCacheDir == "" {
@@ -1720,12 +1782,13 @@ func main() {
 	}
 
 	server := &Server{
-		searchCache:   NewCache(time.Duration(cacheTTLSeconds) * time.Second),
-		resolveCache:  NewResolveCache(),
-		videoCache:    NewVideoCache(videoCacheSize),
-		potCache:      NewPOTokenCache(),
-		diskCache:     diskCache,
-		playlistCache: NewPlaylistCache(playlistCacheTTL),
+		searchCache:           NewCache(time.Duration(cacheTTLSeconds) * time.Second),
+		resolveCache:          NewResolveCache(),
+		videoCache:            NewVideoCache(videoCacheSize),
+		potCache:              NewPOTokenCache(),
+		diskCache:             diskCache,
+		playlistCache:         NewPlaylistCache(playlistCacheTTL),
+		maxCacheableVideoSize: maxCacheableVideoSize,
 	}
 
 	// Initialize and start prefetch queue

--- a/services/youtube-api/main.go
+++ b/services/youtube-api/main.go
@@ -1736,6 +1736,7 @@ func main() {
 	mux.HandleFunc("GET /search", server.handleSearch)
 	mux.HandleFunc("GET /playlist/{playlistId}", server.handlePlaylist)
 	mux.HandleFunc("GET /resolve/{videoId}", server.handleResolve)
+	mux.HandleFunc("GET /analysis/{videoId}", server.handleAnalysis)
 	mux.HandleFunc("GET /proxy/{videoId}", server.handleProxy)
 	mux.HandleFunc("POST /prefetch/{videoId}", server.handlePrefetch)
 	mux.HandleFunc("GET /health", server.handleHealth)

--- a/services/youtube-api/playlist.go
+++ b/services/youtube-api/playlist.go
@@ -1,0 +1,542 @@
+package main
+
+// Public-playlist fetch via InnerTube browse (browseId "VL<playlistId>").
+// Same hand-rolled approach as innertube.go search: no API key quota, no
+// OAuth, direct connection (InnerTube does not need the residential proxy).
+//
+// Playlist markup (verified live 2026-07): items are lockupViewModel entries
+// directly under itemSectionRenderer.contents, with an inline
+// continuationItemRenderer after every ~100 items. Continuation requests
+// only return items when the context carries the visitorData issued by the
+// initial response. The legacy playlistVideoRenderer shape is still parsed
+// as a fallback; unknown renderers are skipped silently and a zero-item page
+// with a title is logged as a drift canary.
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"regexp"
+	"runtime/debug"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/sync/singleflight"
+)
+
+const (
+	innertubeBrowseURL = "https://www.youtube.com/youtubei/v1/browse?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8"
+	// InnerTube pages are ~100 items; 6 requests caps a pathological playlist
+	// at roughly maxPlaylistItems without hammering YouTube.
+	maxPlaylistItems        = 500
+	maxContinuationRequests = 6
+	playlistCacheTTL        = 6 * time.Hour
+)
+
+var (
+	errPlaylistNotFound = errors.New("playlist not found or private")
+	playlistIDRegex     = regexp.MustCompile(`^[A-Za-z0-9_-]{10,64}$`)
+	playlistGroup       singleflight.Group
+)
+
+type PlaylistItem struct {
+	VideoID   string `json:"videoId"`
+	Title     string `json:"title"`
+	Duration  int    `json:"duration"` // seconds, 0 for live/unknown
+	Thumbnail string `json:"thumbnail,omitempty"`
+}
+
+type PlaylistResponse struct {
+	PlaylistID string         `json:"playlistId"`
+	Title      string         `json:"title"`
+	Items      []PlaylistItem `json:"items"`
+	ItemCount  int            `json:"itemCount"`
+	// DeclaredCount is the "N videos" total from the playlist header when
+	// available (0 = unknown). Anonymous InnerTube sessions stop paginating
+	// at ~200 items (2026 server-side cap), so ItemCount can be lower.
+	DeclaredCount int   `json:"declaredCount"`
+	Truncated     bool  `json:"truncated"`
+	Cached        bool  `json:"cached"`
+	CacheAt       int64 `json:"cacheAt,omitempty"`
+}
+
+// PlaylistCache mirrors the search Cache pattern (main.go) for
+// PlaylistResponse values.
+type PlaylistCache struct {
+	mu      sync.RWMutex
+	entries map[string]playlistCacheEntry
+	ttl     time.Duration
+}
+
+type playlistCacheEntry struct {
+	Response  PlaylistResponse
+	ExpiresAt time.Time
+}
+
+func NewPlaylistCache(ttl time.Duration) *PlaylistCache {
+	c := &PlaylistCache{
+		entries: make(map[string]playlistCacheEntry),
+		ttl:     ttl,
+	}
+	go c.cleanupLoop()
+	return c
+}
+
+func (c *PlaylistCache) Get(key string) (PlaylistResponse, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	entry, exists := c.entries[key]
+	if !exists || time.Now().After(entry.ExpiresAt) {
+		return PlaylistResponse{}, false
+	}
+	return entry.Response, true
+}
+
+func (c *PlaylistCache) Set(key string, response PlaylistResponse) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.entries[key] = playlistCacheEntry{
+		Response:  response,
+		ExpiresAt: time.Now().Add(c.ttl),
+	}
+}
+
+func (c *PlaylistCache) cleanupLoop() {
+	ticker := time.NewTicker(30 * time.Minute)
+	for range ticker.C {
+		c.mu.Lock()
+		now := time.Now()
+		for key, entry := range c.entries {
+			if now.After(entry.ExpiresAt) {
+				delete(c.entries, key)
+			}
+		}
+		c.mu.Unlock()
+	}
+}
+
+// innertubeBrowse POSTs one browse request (initial or continuation) and
+// decodes the response.
+func innertubeBrowse(body map[string]interface{}) (map[string]interface{}, error) {
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodPost, innertubeBrowseURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	req.Header.Set("User-Agent", innertubeUserAgent)
+
+	resp, err := innertubeClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	// InnerTube 400s on malformed/nonexistent browse IDs rather than
+	// returning an alert.
+	if resp.StatusCode == http.StatusBadRequest || resp.StatusCode == http.StatusNotFound {
+		return nil, errPlaylistNotFound
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("innertube browse returned status %d", resp.StatusCode)
+	}
+
+	var data map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&data); err != nil {
+		return nil, fmt.Errorf("innertube browse decode failed: %w", err)
+	}
+	return data, nil
+}
+
+// innertubeBrowseContext builds the request context; visitorData must be
+// echoed back on continuation requests or YouTube returns empty pages.
+func innertubeBrowseContext(visitorData string) map[string]interface{} {
+	client := map[string]interface{}{
+		"clientName":       "WEB",
+		"clientVersion":    innertubeClientVersion,
+		"newVisitorCookie": true,
+		"hl":               "en",
+		"gl":               "US",
+	}
+	if visitorData != "" {
+		client["visitorData"] = visitorData
+	}
+	return map[string]interface{}{
+		"client": client,
+		"user":   map[string]interface{}{"lockedSafetyMode": false},
+	}
+}
+
+// playlistSectionItems flattens the initial browse response's sections into
+// one renderer item list. Sections are itemSectionRenderer (whose contents
+// hold the items, possibly wrapped in a legacy playlistVideoListRenderer)
+// with continuationItemRenderer entries appearing either inline in the item
+// list or as sibling sections; both feed the same collector.
+func playlistSectionItems(data map[string]interface{}) []interface{} {
+	tabs, _ := dig(data, "contents", "twoColumnBrowseResultsRenderer", "tabs").([]interface{})
+	if len(tabs) == 0 {
+		return nil
+	}
+	sections, _ := dig(tabs[0], "tabRenderer", "content", "sectionListRenderer", "contents").([]interface{})
+
+	var flat []interface{}
+	for _, section := range sections {
+		if items, ok := dig(section, "itemSectionRenderer", "contents").([]interface{}); ok {
+			if len(items) > 0 {
+				if nested, ok := dig(items[0], "playlistVideoListRenderer", "contents").([]interface{}); ok {
+					items = nested
+				}
+			}
+			flat = append(flat, items...)
+			continue
+		}
+		// Sibling continuation section (small playlists).
+		flat = append(flat, section)
+	}
+	return flat
+}
+
+// innertubeBrowsePlaylist fetches a public playlist's title and items,
+// following continuation tokens up to maxItems.
+func innertubeBrowsePlaylist(playlistID string, maxItems int) (*PlaylistResponse, error) {
+	data, err := innertubeBrowse(map[string]interface{}{
+		"context":  innertubeBrowseContext(""),
+		"browseId": "VL" + playlistID,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if playlistBrowseHasError(data) {
+		return nil, errPlaylistNotFound
+	}
+
+	title := playlistTitle(data)
+	visitorData, _ := dig(data, "responseContext", "visitorData").(string)
+
+	resp := &PlaylistResponse{
+		PlaylistID:    playlistID,
+		Title:         title,
+		DeclaredCount: playlistDeclaredCount(data),
+	}
+	seen := make(map[string]bool)
+	token := collectPlaylistItems(playlistSectionItems(data), &resp.Items, seen, maxItems)
+
+	if len(resp.Items) == 0 && token == "" && title == "" {
+		return nil, errPlaylistNotFound
+	}
+	if len(resp.Items) == 0 && (title != "" || token != "") {
+		log.Printf("[playlist] WARNING: zero items parsed for %s (title=%q, continuation=%v) — possible InnerTube markup drift", playlistID, title, token != "")
+	}
+
+	for requests := 1; token != "" && len(resp.Items) < maxItems && requests < maxContinuationRequests; requests++ {
+		before := len(resp.Items)
+		data, err := innertubeBrowse(map[string]interface{}{
+			"context":      innertubeBrowseContext(visitorData),
+			"continuation": token,
+		})
+		if err != nil {
+			// Return what we have rather than failing a partially fetched list.
+			log.Printf("[playlist] continuation %d failed for %s: %v", requests, playlistID, err)
+			resp.Truncated = true
+			break
+		}
+
+		token = ""
+		actions, _ := dig(data, "onResponseReceivedActions").([]interface{})
+		for _, action := range actions {
+			if contItems, ok := dig(action, "appendContinuationItemsAction", "continuationItems").([]interface{}); ok {
+				if t := collectPlaylistItems(contItems, &resp.Items, seen, maxItems); t != "" {
+					token = t
+				}
+			}
+		}
+		log.Printf("[playlist] continuation %d for %s: %d actions, +%d items, next=%v", requests, playlistID, len(actions), len(resp.Items)-before, token != "")
+		// A sentinel continuation that yields nothing means we're done.
+		if len(resp.Items) == before && token == "" {
+			break
+		}
+	}
+
+	if token != "" || len(resp.Items) > maxItems {
+		resp.Truncated = true
+	}
+	if len(resp.Items) > maxItems {
+		resp.Items = resp.Items[:maxItems]
+	}
+	resp.ItemCount = len(resp.Items)
+	if resp.DeclaredCount > resp.ItemCount {
+		resp.Truncated = true
+	}
+	return resp, nil
+}
+
+// playlistDeclaredCount extracts the "N videos" total from the header
+// metadata rows. Returns 0 when absent (e.g. channel-uploads playlists).
+func playlistDeclaredCount(data map[string]interface{}) int {
+	rows, _ := dig(data, "header", "pageHeaderRenderer", "content", "pageHeaderViewModel", "metadata", "contentMetadataViewModel", "metadataRows").([]interface{})
+	for _, row := range rows {
+		parts, _ := dig(row, "metadataParts").([]interface{})
+		for _, part := range parts {
+			text, ok := dig(part, "text", "content").(string)
+			if !ok {
+				continue
+			}
+			if n, ok := parseVideosCountText(text); ok {
+				return n
+			}
+		}
+	}
+	// Legacy header shape.
+	if n, ok := parseVideosCountText(textOf(dig(data, "header", "playlistHeaderRenderer", "numVideosText"))); ok {
+		return n
+	}
+	return 0
+}
+
+// parseVideosCountText parses strings like "1,234 videos" / "200 videos" /
+// "1 video". Returns (0, false) for anything else.
+func parseVideosCountText(s string) (int, bool) {
+	rest, found := strings.CutSuffix(s, " videos")
+	if !found {
+		rest, found = strings.CutSuffix(s, " video")
+	}
+	if !found {
+		return 0, false
+	}
+	rest = strings.ReplaceAll(rest, ",", "")
+	n, err := strconv.Atoi(rest)
+	if err != nil || n < 0 {
+		return 0, false
+	}
+	return n, true
+}
+
+// collectPlaylistItems walks a renderer list, appending playable entries to
+// out (dedup by video ID) and returning any continuation token found.
+// Handles the current lockupViewModel shape and the legacy
+// playlistVideoRenderer shape; unknown renderer types are skipped.
+func collectPlaylistItems(items []interface{}, out *[]PlaylistItem, seen map[string]bool, maxItems int) string {
+	token := ""
+	for _, it := range items {
+		m, ok := it.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		if cont, ok := m["continuationItemRenderer"].(map[string]interface{}); ok {
+			// Some playlists carry TWO continuation renderers: a real one
+			// inline in the item list and a sentinel as a sibling section
+			// that returns nothing. First token wins (inline comes first).
+			if t, ok := dig(cont, "continuationEndpoint", "continuationCommand", "token").(string); ok && token == "" {
+				token = t
+			}
+			continue
+		}
+
+		var item PlaylistItem
+		if lv, ok := m["lockupViewModel"].(map[string]interface{}); ok {
+			item, ok = parseLockupViewModel(lv)
+			if !ok {
+				continue
+			}
+		} else if vr, ok := m["playlistVideoRenderer"].(map[string]interface{}); ok {
+			item, ok = parsePlaylistVideoRenderer(vr)
+			if !ok {
+				continue
+			}
+		} else {
+			continue
+		}
+
+		if len(*out) >= maxItems || seen[item.VideoID] {
+			continue
+		}
+		seen[item.VideoID] = true
+		*out = append(*out, item)
+	}
+	return token
+}
+
+// parseLockupViewModel extracts a playlist entry from the current (2026)
+// lockup markup: contentId carries the video ID, the title lives at
+// metadata.lockupMetadataViewModel.title.content, and the duration is a
+// "3:45"-style thumbnail badge.
+func parseLockupViewModel(lv map[string]interface{}) (PlaylistItem, bool) {
+	if ct, ok := lv["contentType"].(string); ok && ct != "LOCKUP_CONTENT_TYPE_VIDEO" {
+		return PlaylistItem{}, false
+	}
+	id, _ := lv["contentId"].(string)
+	if id == "" {
+		return PlaylistItem{}, false
+	}
+
+	item := PlaylistItem{VideoID: id}
+	if t, ok := dig(lv, "metadata", "lockupMetadataViewModel", "title", "content").(string); ok {
+		item.Title = t
+	}
+
+	thumbVM := dig(lv, "contentImage", "thumbnailViewModel")
+	if sources, ok := dig(thumbVM, "image", "sources").([]interface{}); ok && len(sources) > 0 {
+		if s0, ok := sources[0].(map[string]interface{}); ok {
+			item.Thumbnail, _ = s0["url"].(string)
+		}
+	}
+	// Duration badge: overlays[].thumbnailBottomOverlayViewModel.badges[]
+	// .thumbnailBadgeViewModel.text — "1:30" for videos, "LIVE" etc. parse
+	// to 0 via parseDurationText.
+	if overlays, ok := dig(thumbVM, "overlays").([]interface{}); ok {
+		for _, overlay := range overlays {
+			badges, ok := dig(overlay, "thumbnailBottomOverlayViewModel", "badges").([]interface{})
+			if !ok {
+				continue
+			}
+			for _, badge := range badges {
+				if text, ok := dig(badge, "thumbnailBadgeViewModel", "text").(string); ok {
+					if d := parseDurationText(text); d > 0 {
+						item.Duration = d
+					}
+				}
+			}
+		}
+	}
+
+	return item, true
+}
+
+// parsePlaylistVideoRenderer extracts a playlist entry from the legacy
+// markup. Deleted/private/region-locked entries carry isPlayable: false.
+func parsePlaylistVideoRenderer(vr map[string]interface{}) (PlaylistItem, bool) {
+	id, _ := vr["videoId"].(string)
+	if id == "" {
+		return PlaylistItem{}, false
+	}
+	if playable, ok := vr["isPlayable"].(bool); ok && !playable {
+		return PlaylistItem{}, false
+	}
+
+	item := PlaylistItem{
+		VideoID: id,
+		Title:   textOf(vr["title"]),
+	}
+	// lengthSeconds is a STRING in playlistVideoRenderer; absent for live.
+	if ls, ok := vr["lengthSeconds"].(string); ok {
+		if n, err := strconv.Atoi(ls); err == nil {
+			item.Duration = n
+		}
+	}
+	if thumbs, ok := dig(vr, "thumbnail", "thumbnails").([]interface{}); ok && len(thumbs) > 0 {
+		if t0, ok := thumbs[0].(map[string]interface{}); ok {
+			item.Thumbnail, _ = t0["url"].(string)
+		}
+	}
+	return item, true
+}
+
+func playlistTitle(data map[string]interface{}) string {
+	if t, ok := dig(data, "metadata", "playlistMetadataRenderer", "title").(string); ok && t != "" {
+		return t
+	}
+	if t := textOf(dig(data, "header", "playlistHeaderRenderer", "title")); t != "" {
+		return t
+	}
+	if t, ok := dig(data, "microformat", "microformatDataRenderer", "title").(string); ok {
+		return t
+	}
+	return ""
+}
+
+// playlistBrowseHasError reports whether the browse response carries an
+// ERROR alert (nonexistent or private playlist).
+func playlistBrowseHasError(data map[string]interface{}) bool {
+	alerts, _ := data["alerts"].([]interface{})
+	for _, a := range alerts {
+		if t, ok := dig(a, "alertRenderer", "type").(string); ok && t == "ERROR" {
+			return true
+		}
+	}
+	return false
+}
+
+// validImportablePlaylistID rejects malformed IDs plus mixes (RD*) and
+// private auth-required lists (WL, LL), which InnerTube cannot browse.
+func validImportablePlaylistID(id string) bool {
+	if !playlistIDRegex.MatchString(id) {
+		return false
+	}
+	if id == "WL" || id == "LL" {
+		return false
+	}
+	if len(id) >= 2 && id[:2] == "RD" {
+		return false
+	}
+	return true
+}
+
+func (s *Server) handlePlaylist(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+
+	// Same safety net as handleSearch: a parser bug must never abort the
+	// connection.
+	defer func() {
+		if rec := recover(); rec != nil {
+			log.Printf("[playlist] PANIC id='%s': %v\n%s", r.PathValue("playlistId"), rec, debug.Stack())
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]string{"error": "playlist fetch failed"})
+		}
+	}()
+
+	playlistID := r.PathValue("playlistId")
+	if !validImportablePlaylistID(playlistID) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		json.NewEncoder(w).Encode(map[string]string{"error": "invalid or unsupported playlist id (mixes and private lists cannot be imported)"})
+		return
+	}
+
+	if cached, found := s.playlistCache.Get(playlistID); found {
+		cached.Cached = true
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(cached)
+		log.Printf("[playlist] CACHE HIT id=%s duration=%v", playlistID, time.Since(start))
+		return
+	}
+
+	result, err, shared := playlistGroup.Do(playlistID, func() (interface{}, error) {
+		log.Printf("[playlist] CACHE MISS id=%s (fetching from YouTube)", playlistID)
+		resp, err := innertubeBrowsePlaylist(playlistID, maxPlaylistItems)
+		if err != nil {
+			return nil, err
+		}
+		resp.CacheAt = time.Now().Unix()
+		s.playlistCache.Set(playlistID, *resp)
+		return *resp, nil
+	})
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		if errors.Is(err, errPlaylistNotFound) {
+			w.WriteHeader(http.StatusNotFound)
+			json.NewEncoder(w).Encode(map[string]string{"error": "playlist not found or private"})
+		} else {
+			log.Printf("[playlist] ERROR id=%s: %v", playlistID, err)
+			w.WriteHeader(http.StatusBadGateway)
+			json.NewEncoder(w).Encode(map[string]string{"error": "playlist fetch failed"})
+		}
+		return
+	}
+
+	response := result.(PlaylistResponse)
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(response)
+	log.Printf("[playlist] id=%s items=%d truncated=%v shared=%v duration=%v", playlistID, response.ItemCount, response.Truncated, shared, time.Since(start))
+}

--- a/services/youtube-api/playlist_test.go
+++ b/services/youtube-api/playlist_test.go
@@ -1,0 +1,253 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func playlistVideoFixture(id, title, lengthSeconds string, playable *bool) map[string]interface{} {
+	vr := map[string]interface{}{
+		"videoId": id,
+		"title": map[string]interface{}{
+			"runs": []interface{}{map[string]interface{}{"text": title}},
+		},
+		"thumbnail": map[string]interface{}{
+			"thumbnails": []interface{}{
+				map[string]interface{}{"url": "https://i.ytimg.com/vi/" + id + "/default.jpg"},
+			},
+		},
+	}
+	if lengthSeconds != "" {
+		vr["lengthSeconds"] = lengthSeconds
+	}
+	if playable != nil {
+		vr["isPlayable"] = *playable
+	}
+	return map[string]interface{}{"playlistVideoRenderer": vr}
+}
+
+func lockupFixture(id, title, badgeText string) map[string]interface{} {
+	return map[string]interface{}{
+		"lockupViewModel": map[string]interface{}{
+			"contentId":   id,
+			"contentType": "LOCKUP_CONTENT_TYPE_VIDEO",
+			"metadata": map[string]interface{}{
+				"lockupMetadataViewModel": map[string]interface{}{
+					"title": map[string]interface{}{"content": title},
+				},
+			},
+			"contentImage": map[string]interface{}{
+				"thumbnailViewModel": map[string]interface{}{
+					"image": map[string]interface{}{
+						"sources": []interface{}{
+							map[string]interface{}{"url": "https://i.ytimg.com/vi/" + id + "/hqdefault.jpg"},
+						},
+					},
+					"overlays": []interface{}{
+						map[string]interface{}{
+							"thumbnailBottomOverlayViewModel": map[string]interface{}{
+								"badges": []interface{}{
+									map[string]interface{}{
+										"thumbnailBadgeViewModel": map[string]interface{}{"text": badgeText},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func continuationFixture(token string) map[string]interface{} {
+	return map[string]interface{}{
+		"continuationItemRenderer": map[string]interface{}{
+			"continuationEndpoint": map[string]interface{}{
+				"continuationCommand": map[string]interface{}{"token": token},
+			},
+		},
+	}
+}
+
+func TestCollectPlaylistItems(t *testing.T) {
+	playable := true
+	unplayable := false
+	items := []interface{}{
+		playlistVideoFixture("aaaaaaaaaaa", "First Track", "212", &playable),
+		playlistVideoFixture("bbbbbbbbbbb", "[Deleted video]", "", &unplayable), // skipped: unplayable
+		playlistVideoFixture("ccccccccccc", "Live Stream", "", nil),             // kept: duration 0
+		playlistVideoFixture("aaaaaaaaaaa", "First Track dup", "212", nil),      // skipped: dedup
+		map[string]interface{}{"lockupViewModel": map[string]interface{}{}},     // skipped: unknown renderer
+		"not a map", // skipped: wrong type
+		continuationFixture("CONT_TOKEN_123"),
+	}
+
+	var out []PlaylistItem
+	seen := make(map[string]bool)
+	token := collectPlaylistItems(items, &out, seen, maxPlaylistItems)
+
+	if token != "CONT_TOKEN_123" {
+		t.Errorf("token = %q, want CONT_TOKEN_123", token)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want 2 (got %+v)", len(out), out)
+	}
+	if out[0].VideoID != "aaaaaaaaaaa" || out[0].Title != "First Track" || out[0].Duration != 212 {
+		t.Errorf("first item wrong: %+v", out[0])
+	}
+	if out[0].Thumbnail == "" {
+		t.Errorf("first item missing thumbnail")
+	}
+	if out[1].VideoID != "ccccccccccc" || out[1].Duration != 0 {
+		t.Errorf("live item wrong: %+v", out[1])
+	}
+}
+
+func TestCollectPlaylistItemsLockup(t *testing.T) {
+	items := []interface{}{
+		lockupFixture("dddddddddd1", "Lockup Track", "3:45"),
+		lockupFixture("eeeeeeeeee1", "Live Lockup", "LIVE"), // badge unparseable → duration 0
+		map[string]interface{}{ // non-video lockup (e.g. a playlist card) → skipped
+			"lockupViewModel": map[string]interface{}{
+				"contentId":   "PLnested",
+				"contentType": "LOCKUP_CONTENT_TYPE_PLAYLIST",
+			},
+		},
+		continuationFixture("LOCKUP_CONT"),
+	}
+
+	var out []PlaylistItem
+	token := collectPlaylistItems(items, &out, make(map[string]bool), maxPlaylistItems)
+
+	if token != "LOCKUP_CONT" {
+		t.Errorf("token = %q, want LOCKUP_CONT", token)
+	}
+	if len(out) != 2 {
+		t.Fatalf("len(out) = %d, want 2 (got %+v)", len(out), out)
+	}
+	if out[0].VideoID != "dddddddddd1" || out[0].Title != "Lockup Track" || out[0].Duration != 225 {
+		t.Errorf("lockup item wrong: %+v", out[0])
+	}
+	if out[0].Thumbnail == "" {
+		t.Errorf("lockup item missing thumbnail")
+	}
+	if out[1].Duration != 0 {
+		t.Errorf("live lockup duration = %d, want 0", out[1].Duration)
+	}
+}
+
+func TestCollectPlaylistItemsRespectsMax(t *testing.T) {
+	items := []interface{}{
+		playlistVideoFixture("aaaaaaaaaaa", "One", "10", nil),
+		playlistVideoFixture("bbbbbbbbbbb", "Two", "20", nil),
+		playlistVideoFixture("ccccccccccc", "Three", "30", nil),
+	}
+	var out []PlaylistItem
+	collectPlaylistItems(items, &out, make(map[string]bool), 2)
+	if len(out) != 2 {
+		t.Errorf("len(out) = %d, want 2 (max cap)", len(out))
+	}
+}
+
+func TestPlaylistTitleFallbacks(t *testing.T) {
+	metadata := map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"playlistMetadataRenderer": map[string]interface{}{"title": "Meta Title"},
+		},
+	}
+	if got := playlistTitle(metadata); got != "Meta Title" {
+		t.Errorf("metadata title = %q", got)
+	}
+
+	header := map[string]interface{}{
+		"header": map[string]interface{}{
+			"playlistHeaderRenderer": map[string]interface{}{
+				"title": map[string]interface{}{"simpleText": "Header Title"},
+			},
+		},
+	}
+	if got := playlistTitle(header); got != "Header Title" {
+		t.Errorf("header title = %q", got)
+	}
+
+	if got := playlistTitle(map[string]interface{}{}); got != "" {
+		t.Errorf("empty response title = %q, want empty", got)
+	}
+}
+
+func TestPlaylistBrowseHasError(t *testing.T) {
+	errResp := map[string]interface{}{
+		"alerts": []interface{}{
+			map[string]interface{}{
+				"alertRenderer": map[string]interface{}{
+					"type": "ERROR",
+					"text": map[string]interface{}{"simpleText": "The playlist does not exist."},
+				},
+			},
+		},
+	}
+	if !playlistBrowseHasError(errResp) {
+		t.Error("expected error alert to be detected")
+	}
+
+	infoResp := map[string]interface{}{
+		"alerts": []interface{}{
+			map[string]interface{}{
+				"alertRenderer": map[string]interface{}{"type": "INFO"},
+			},
+		},
+	}
+	if playlistBrowseHasError(infoResp) {
+		t.Error("INFO alert must not be treated as error")
+	}
+	if playlistBrowseHasError(map[string]interface{}{}) {
+		t.Error("no alerts must not be treated as error")
+	}
+}
+
+func TestValidImportablePlaylistID(t *testing.T) {
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"PLBCF2DAC6FFB574DE", true},
+		{"PL1234567890abcdef", true},
+		{"OLAK5uy_abcdefghij", true},
+		{"UUabcdefghij", true},
+		{"WL", false},               // watch later (auth required)
+		{"LL", false},               // liked (auth required)
+		{"RDdQw4w9WgXcQ", false},    // radio/mix
+		{"short", false},            // too short
+		{"has spaces in it", false}, // invalid chars
+		{"", false},
+	}
+	for _, c := range cases {
+		if got := validImportablePlaylistID(c.id); got != c.want {
+			t.Errorf("validImportablePlaylistID(%q) = %v, want %v", c.id, got, c.want)
+		}
+	}
+}
+
+// TestPlaylistResponseJSONShape pins the wire format the client depends on.
+func TestPlaylistResponseJSONShape(t *testing.T) {
+	resp := PlaylistResponse{
+		PlaylistID: "PLtest12345",
+		Title:      "Test",
+		Items:      []PlaylistItem{{VideoID: "aaaaaaaaaaa", Title: "T", Duration: 60, Thumbnail: "u"}},
+		ItemCount:  1,
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var m map[string]interface{}
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"playlistId", "title", "items", "itemCount", "truncated", "cached"} {
+		if _, ok := m[key]; !ok {
+			t.Errorf("missing key %q in JSON: %s", key, b)
+		}
+	}
+}

--- a/services/youtube-api/prefetch_queue.go
+++ b/services/youtube-api/prefetch_queue.go
@@ -402,6 +402,14 @@ func (pq *PrefetchQueue) doPrefetchAudio(videoID string) {
 	}
 
 	log.Printf("[prefetch-queue] Cached %s audio (%d bytes)", videoID, len(audioData))
+
+	// Analyze the freshly cached audio to produce the precomputed FFT
+	// timeline. Synchronous here (we're already in a goroutine); the CPU
+	// semaphore inside runAnalysis serializes the heavy work. Failures are
+	// non-fatal — the live analyser path covers misses on the client.
+	if err := pq.server.runAnalysis(videoID, audioData); err != nil {
+		log.Printf("[prefetch-queue] Analysis failed for %s: %v", videoID, err)
+	}
 }
 
 func (pq *PrefetchQueue) addToHistory(job *PrefetchJob) {

--- a/services/youtube-api/prefetch_queue.go
+++ b/services/youtube-api/prefetch_queue.go
@@ -317,15 +317,20 @@ func (pq *PrefetchQueue) doPrefetch(videoID string) error {
 		return fmt.Errorf("bad status: %d", resp.StatusCode)
 	}
 
-	data, err := io.ReadAll(io.LimitReader(resp.Body, MaxCacheableVideoSize))
+	data, err := io.ReadAll(io.LimitReader(resp.Body, pq.server.maxCacheableVideoSize+1))
 	if err != nil {
 		return fmt.Errorf("read failed: %w", err)
 	}
+	if int64(len(data)) > pq.server.maxCacheableVideoSize {
+		return fmt.Errorf("video too large to cache (%d bytes)", len(data))
+	}
 
-	// Cache in memory
-	pq.server.videoCache.Set(cacheKey, data)
-
-	// Cache on disk
+	// Entries at or below the memory threshold go to both memory and disk;
+	// larger entries go to disk only so one long video doesn't evict the hot
+	// memory set.
+	if int64(len(data)) <= MemoryCacheMaxEntrySize {
+		pq.server.videoCache.Set(cacheKey, data)
+	}
 	if pq.server.diskCache != nil {
 		pq.server.diskCache.Set(cacheKey, data)
 	}
@@ -390,13 +395,19 @@ func (pq *PrefetchQueue) doPrefetchAudio(videoID string) {
 		return
 	}
 
-	audioData, err := io.ReadAll(io.LimitReader(resp.Body, MaxCacheableVideoSize))
+	audioData, err := io.ReadAll(io.LimitReader(resp.Body, pq.server.maxCacheableVideoSize+1))
 	if err != nil {
 		log.Printf("[prefetch-queue] Audio read failed for %s: %v", videoID, err)
 		return
 	}
+	if int64(len(audioData)) > pq.server.maxCacheableVideoSize {
+		log.Printf("[prefetch-queue] Audio too large to cache for %s (%d bytes)", videoID, len(audioData))
+		return
+	}
 
-	pq.server.videoCache.Set(audioCacheKey, audioData)
+	if int64(len(audioData)) <= MemoryCacheMaxEntrySize {
+		pq.server.videoCache.Set(audioCacheKey, audioData)
+	}
 	if pq.server.diskCache != nil {
 		pq.server.diskCache.Set(audioCacheKey, audioData)
 	}

--- a/services/youtube-api/proxy_range.go
+++ b/services/youtube-api/proxy_range.go
@@ -1,0 +1,150 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+)
+
+// rangeStatus describes how the caller should handle a parsed Range header.
+type rangeStatus int
+
+const (
+	// rangeNone: no Range header present — serve full 200.
+	rangeNone rangeStatus = iota
+	// rangeMalformed: syntactically invalid — per RFC 7233, ignore and serve full 200.
+	rangeMalformed
+	// rangeMultipart: multipart range (e.g. "bytes=0-1,5-9") — caller should pass
+	// the request through to upstream unchanged.
+	rangeMultipart
+	// rangeUnsatisfiable: syntactically valid single range but start >= size —
+	// respond 416 with Content-Range: bytes */<size>.
+	rangeUnsatisfiable
+	// rangeOK: satisfiable single range — respond 206 with the inclusive [start,end] slice.
+	rangeOK
+)
+
+// parseRangeDetailed parses a Range header value against a resource of the given
+// size. It returns the inclusive [start, end] byte range (valid when status ==
+// rangeOK) and a status code describing how the caller should handle the result.
+//
+// Supported forms:
+//   - "bytes=X-Y"  → bytes X through Y inclusive
+//   - "bytes=X-"   → bytes X through the end
+//   - "bytes=-N"   → the last N bytes (suffix range)
+//
+// Multipart ranges ("bytes=0-1,5-9") are detected and surfaced as rangeMultipart
+// so the caller can pass them through to the upstream proxy. The end value is
+// clamped to size-1 when it exceeds the resource; suffix ranges larger than the
+// resource clamp to the full resource.
+func parseRangeDetailed(header string, size int64) (start, end int64, status rangeStatus) {
+	header = strings.TrimSpace(header)
+	if header == "" {
+		return 0, 0, rangeNone
+	}
+	if !strings.HasPrefix(header, "bytes=") {
+		return 0, 0, rangeMalformed
+	}
+	spec := strings.TrimPrefix(header, "bytes=")
+	if strings.Contains(spec, ",") {
+		return 0, 0, rangeMultipart
+	}
+	dash := strings.IndexByte(spec, '-')
+	if dash < 0 {
+		return 0, 0, rangeMalformed
+	}
+	left := strings.TrimSpace(spec[:dash])
+	right := strings.TrimSpace(spec[dash+1:])
+
+	if left == "" {
+		// Suffix range: bytes=-N (last N bytes).
+		if right == "" {
+			return 0, 0, rangeMalformed
+		}
+		n, err := strconv.ParseInt(right, 10, 64)
+		if err != nil || n <= 0 {
+			return 0, 0, rangeMalformed
+		}
+		if size <= 0 {
+			return 0, 0, rangeUnsatisfiable
+		}
+		if n >= size {
+			return 0, size - 1, rangeOK
+		}
+		return size - n, size - 1, rangeOK
+	}
+
+	startNum, err := strconv.ParseInt(left, 10, 64)
+	if err != nil || startNum < 0 {
+		return 0, 0, rangeMalformed
+	}
+
+	if right == "" {
+		// Open-ended: bytes=X- → X to end.
+		if size <= 0 || startNum >= size {
+			return 0, 0, rangeUnsatisfiable
+		}
+		return startNum, size - 1, rangeOK
+	}
+
+	endNum, err := strconv.ParseInt(right, 10, 64)
+	if err != nil || endNum < 0 {
+		return 0, 0, rangeMalformed
+	}
+	if startNum > endNum {
+		return 0, 0, rangeMalformed
+	}
+	if size <= 0 || startNum >= size {
+		return 0, 0, rangeUnsatisfiable
+	}
+	if endNum >= size {
+		endNum = size - 1
+	}
+	return startNum, endNum, rangeOK
+}
+
+// parseByteRange is the simplified Range parser.
+// It returns (start, end, true) for a satisfiable single range (end inclusive),
+// or (0, 0, false) for empty / malformed / multipart / unsatisfiable ranges.
+// Callers that need to distinguish between those cases should use parseRangeDetailed.
+func parseByteRange(header string, size int64) (start, end int64, ok bool) {
+	s, e, status := parseRangeDetailed(header, size)
+	if status != rangeOK {
+		return 0, 0, false
+	}
+	return s, e, true
+}
+
+// contentRangeCoversFull reports whether a Content-Range header value describes a
+// 206 response that carries the entire resource starting at byte 0 — i.e. the
+// form "bytes 0-<last>/<total>" with last+1 == total. Such responses are produced
+// for "Range: bytes=0-" requests and are safe to cache as the full resource.
+func contentRangeCoversFull(cr string) bool {
+	cr = strings.TrimSpace(cr)
+	const prefix = "bytes "
+	if !strings.HasPrefix(cr, prefix) {
+		return false
+	}
+	rest := strings.TrimPrefix(cr, prefix)
+	slash := strings.IndexByte(rest, '/')
+	if slash < 0 {
+		return false
+	}
+	rangePart := rest[:slash]
+	totalStr := rest[slash+1:]
+	total, err := strconv.ParseInt(totalStr, 10, 64)
+	if err != nil || total <= 0 {
+		return false
+	}
+	dash := strings.IndexByte(rangePart, '-')
+	if dash < 0 {
+		return false
+	}
+	startStr := rangePart[:dash]
+	endStr := rangePart[dash+1:]
+	start, err1 := strconv.ParseInt(startStr, 10, 64)
+	end, err2 := strconv.ParseInt(endStr, 10, 64)
+	if err1 != nil || err2 != nil {
+		return false
+	}
+	return start == 0 && end+1 == total
+}

--- a/services/youtube-api/proxy_range_test.go
+++ b/services/youtube-api/proxy_range_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestParseByteRange(t *testing.T) {
+	const size = int64(1000)
+
+	cases := []struct {
+		name     string
+		header   string
+		wantStart int64
+		wantEnd   int64
+		wantOK    bool
+	}{
+		{"simple_range", "bytes=0-99", 0, 99, true},
+		{"range_in_middle", "bytes=100-199", 100, 199, true},
+		{"open_ended", "bytes=100-", 100, 999, true},
+		{"open_ended_at_zero", "bytes=0-", 0, 999, true},
+		{"suffix", "bytes=-500", 500, 999, true},
+		{"suffix_small", "bytes=-1", 999, 999, true},
+		{"single_byte", "bytes=0-0", 0, 0, true},
+		{"last_byte", "bytes=999-999", 999, 999, true},
+		{"end_past_size_clamps", "bytes=0-2000", 0, 999, true},
+		{"end_past_size_from_middle", "bytes=500-2000", 500, 999, true},
+		{"suffix_larger_than_size_clamps", "bytes=-5000", 0, 999, true},
+
+		// Malformed / not-satisfiable cases → ok=false.
+		{"empty_range", "bytes=", 0, 0, false},
+		{"only_prefix", "bytes=", 0, 0, false},
+		{"non_numeric", "bytes=a-b", 0, 0, false},
+		{"non_numeric_left", "bytes=x-99", 0, 0, false},
+		{"non_numeric_right", "bytes=0-x", 0, 0, false},
+		{"wrong_unit", "items=0-1", 0, 0, false},
+		{"no_dash", "bytes=0100", 0, 0, false},
+		{"reverse_range", "bytes=200-100", 0, 0, false},
+		{"negative_start", "bytes=-1-50", 0, 0, false},
+		{"zero_suffix", "bytes=-0", 0, 0, false},
+		{"multipart", "bytes=0-1,5-9", 0, 0, false},
+
+		// Unsatisfiable cases → ok=false (caller distinguishes via parseRangeDetailed).
+		{"start_at_size", "bytes=1000-", 0, 0, false},
+		{"start_past_size", "bytes=999999-", 0, 0, false},
+		{"start_past_size_bounded", "bytes=2000-3000", 0, 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			start, end, ok := parseByteRange(tc.header, size)
+			if ok != tc.wantOK {
+				t.Fatalf("parseByteRange(%q, %d): ok = %v, want %v", tc.header, size, ok, tc.wantOK)
+			}
+			if ok && (start != tc.wantStart || end != tc.wantEnd) {
+				t.Errorf("parseByteRange(%q, %d): start,end = (%d,%d), want (%d,%d)",
+					tc.header, size, start, end, tc.wantStart, tc.wantEnd)
+			}
+		})
+	}
+}
+
+func TestParseRangeDetailedUnsatisfiable(t *testing.T) {
+	// parseByteRange collapses unsatisfiable + malformed into ok=false.
+	// Verify parseRangeDetailed distinguishes them so the proxy handler can
+	// emit a proper 416.
+	const size = int64(1000)
+	cases := []struct {
+		name       string
+		header     string
+		wantStatus rangeStatus
+	}{
+		{"none", "", rangeNone},
+		{"malformed", "bytes=a-b", rangeMalformed},
+		{"wrong_unit", "items=0-1", rangeMalformed},
+		{"multipart", "bytes=0-1,5-9", rangeMultipart},
+		{"start_at_size_open", "bytes=1000-", rangeUnsatisfiable},
+		{"start_past_size_open", "bytes=999999-", rangeUnsatisfiable},
+		{"start_past_size_bounded", "bytes=2000-3000", rangeUnsatisfiable},
+		{"satisfiable", "bytes=100-199", rangeOK},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, status := parseRangeDetailed(tc.header, size)
+			if status != tc.wantStatus {
+				t.Fatalf("parseRangeDetailed(%q, %d): status = %v, want %v",
+					tc.header, size, status, tc.wantStatus)
+			}
+		})
+	}
+}
+
+func TestContentRangeCoversFull(t *testing.T) {
+	cases := []struct {
+		cr   string
+		want bool
+	}{
+		{"bytes 0-999/1000", true},
+		{"bytes 0-0/1", true},
+		{"bytes 0-99/100", true},
+		{"bytes 100-999/1000", false}, // doesn't start at 0
+		{"bytes 0-499/1000", false},   // doesn't cover the full length
+		{"bytes */1000", false},       // wildcard form
+		{"bytes */0", false},
+		{"", false},
+		{"bytes 0-99/", false},    // missing total
+		{"bytes 0-99/abc", false}, // non-numeric total
+		{"bytes -99/100", false},  // missing start
+		{"bytes 0/100", false},    // missing dash
+		{"items 0-99/100", false}, // wrong unit
+	}
+	for _, tc := range cases {
+		t.Run(tc.cr, func(t *testing.T) {
+			got := contentRangeCoversFull(tc.cr)
+			if got != tc.want {
+				t.Errorf("contentRangeCoversFull(%q) = %v, want %v", tc.cr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHandleProxyServesRangeFromCache(t *testing.T) {
+	// Seed video cache with 100 bytes (0..99).
+	const size = 100
+	data := make([]byte, size)
+	for i := range data {
+		data[i] = byte(i)
+	}
+	s := &Server{
+		videoCache:            NewVideoCache(DefaultVideoCacheMaxSize),
+		maxCacheableVideoSize: DefaultMaxCacheableVideoSize,
+	}
+	s.videoCache.Set("AAAAAAAAAAA:video", data)
+
+	cases := []struct {
+		name       string
+		rangeHdr   string
+		wantStatus int
+		wantCR     string // Content-Range header; "" → don't check
+		wantCL     string // Content-Length header; "" → don't check
+		wantBody   []byte // expected body; nil → don't check
+	}{
+		{
+			name:       "range_10_19",
+			rangeHdr:   "bytes=10-19",
+			wantStatus: http.StatusPartialContent,
+			wantCR:     "bytes 10-19/100",
+			wantCL:     "10",
+			wantBody:   data[10:20],
+		},
+		{
+			name:       "range_90_open",
+			rangeHdr:   "bytes=90-",
+			wantStatus: http.StatusPartialContent,
+			wantCR:     "bytes 90-99/100",
+			wantCL:     "10",
+			wantBody:   data[90:100],
+		},
+		{
+			name:       "range_to_end_clamped",
+			rangeHdr:   "bytes=50-9999",
+			wantStatus: http.StatusPartialContent,
+			wantCR:     "bytes 50-99/100",
+			wantCL:     "50",
+			wantBody:   data[50:100],
+		},
+		{
+			name:       "suffix_last_5",
+			rangeHdr:   "bytes=-5",
+			wantStatus: http.StatusPartialContent,
+			wantCR:     "bytes 95-99/100",
+			wantCL:     "5",
+			wantBody:   data[95:100],
+		},
+		{
+			name:       "suffix_larger_than_size",
+			rangeHdr:   "bytes=-5000",
+			wantStatus: http.StatusPartialContent,
+			wantCR:     "bytes 0-99/100",
+			wantCL:     "100",
+			wantBody:   data[0:100],
+		},
+		{
+			name:       "single_byte",
+			rangeHdr:   "bytes=0-0",
+			wantStatus: http.StatusPartialContent,
+			wantCR:     "bytes 0-0/100",
+			wantCL:     "1",
+			wantBody:   data[0:1],
+		},
+		{
+			name:       "unsatisfiable",
+			rangeHdr:   "bytes=999999-",
+			wantStatus: http.StatusRequestedRangeNotSatisfiable,
+			wantCR:     "bytes */100",
+		},
+		{
+			name:       "malformed_ignored_serves_full",
+			rangeHdr:   "bytes=a-b",
+			wantStatus: http.StatusOK,
+			wantCL:     "100",
+			wantBody:   data,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/proxy/AAAAAAAAAAA", nil)
+			if tc.rangeHdr != "" {
+				req.Header.Set("Range", tc.rangeHdr)
+			}
+			rec := httptest.NewRecorder()
+			s.handleProxy(rec, req)
+
+			if rec.Code != tc.wantStatus {
+				t.Fatalf("status = %d, want %d (body=%q)", rec.Code, tc.wantStatus, rec.Body.String())
+			}
+			if tc.wantCR != "" {
+				if got := rec.Header().Get("Content-Range"); got != tc.wantCR {
+					t.Errorf("Content-Range = %q, want %q", got, tc.wantCR)
+				}
+			}
+			if tc.wantCL != "" {
+				if got := rec.Header().Get("Content-Length"); got != tc.wantCL {
+					t.Errorf("Content-Length = %q, want %q", got, tc.wantCL)
+				}
+			}
+			if tc.wantBody != nil {
+				if !bytes.Equal(rec.Body.Bytes(), tc.wantBody) {
+					t.Errorf("body len=%d (%v), want len=%d (%v)",
+						rec.Body.Len(), rec.Body.Bytes()[:min(8, rec.Body.Len())],
+						len(tc.wantBody), tc.wantBody[:min(8, len(tc.wantBody))])
+				}
+			}			// Cache hits should always advertise range support + cache-control.
+			if got := rec.Header().Get("Accept-Ranges"); got != "bytes" {
+				t.Errorf("Accept-Ranges = %q, want %q", got, "bytes")
+			}
+			if got := rec.Header().Get("Cache-Control"); got != "public, max-age=3600" {
+				t.Errorf("Cache-Control = %q, want %q", got, "public, max-age=3600")
+			}
+		})
+	}
+}
+
+func TestHandleProxyServesFullFromCacheNoRange(t *testing.T) {
+	data := []byte("hello world this is cached video data")
+	s := &Server{
+		videoCache:            NewVideoCache(DefaultVideoCacheMaxSize),
+		maxCacheableVideoSize: DefaultMaxCacheableVideoSize,
+	}
+	s.videoCache.Set("AAAAAAAAAAA:video", data)
+
+	req := httptest.NewRequest("GET", "/proxy/AAAAAAAAAAA", nil)
+	rec := httptest.NewRecorder()
+	s.handleProxy(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if got := rec.Header().Get("Content-Length"); got != "37" {
+		t.Errorf("Content-Length = %q, want %q", got, "37")
+	}
+	if !bytes.Equal(rec.Body.Bytes(), data) {
+		t.Errorf("body = %q, want %q", rec.Body.String(), string(data))
+	}
+}


### PR DESCRIPTION
## Summary

Three improvements to the YouTube streaming stack, from the investigation into proxy costs and playlist syncing:

### 1. Playlist import (no API key)
- New `GET /playlist/{playlistId}` in `services/youtube-api` via free InnerTube browse (`VL<id>`)
- Parses YouTube's **2026 `lockupViewModel` markup** (legacy `playlistVideoRenderer` kept as fallback, drift canary logged); continuations carry `visitorData` (required or pages come back empty); handles the dual inline+sentinel continuation quirk
- Anonymous InnerTube sessions hard-cap at ~200 items — `declaredCount`/`truncated` let the UI report "imported first 200 of 2120 tracks" honestly
- Paste-URL import in **MyPlaylistsPanel** and **MutantTube** (KonpyuuTA); mixes (`RD*`) and private lists (`WL`/`LL`) rejected client- and server-side
- **Nakama**: `MAX_TRACKS_PER_PLAYLIST` 100→500, `MAX_PLAYLISTS` 50→100, `list_playlists` gains `include_items:false` metadata mode, new `get_playlist` RPC (ES5)
- **Lazy playlist loading**: startup fetches metadata only; tracks load on open (`ensureItemsLoaded`), with guards so a metadata-only playlist can never be saved back over server items

### 2. Precomputed audio-reactivity (kills per-client proxy audio streams)
- `GET /analysis/{videoId}`: server decodes cached audio once (ffmpeg → pure-Go radix-2 FFT) into a compact band timeline (~3KB per 30s; 200/202-pending/404-unavailable semantics), hooked into the prefetch pipeline
- `useAudioAnalyser` prefers the timeline, driving `bass/mid/high/energy` from the TimeSync-corrected playback clock — no `<audio>` element, no AudioContext, no per-client proxy stream; live analyser remains as fallback; dream mode untouched

### 3. Proxy range/cache fixes (byte-serving stops paying the proxy twice)
- Cached entries now serve arbitrary single `Range` requests locally (RFC 7233: 206 slicing, 416 unsatisfiable, malformed→200, multipart→upstream passthrough)
- `Range: bytes=0-` upstream 206 responses (what media elements actually send) are now cached when `Content-Range` covers the full resource
- Per-entry cap configurable via `MAX_CACHEABLE_VIDEO_MB` (default 50, was hardcoded 15); entries >15MB go disk-only to protect the hot memory LRU
- Fixes a latent bug: prefetch previously cached silently-truncated 15MB files for oversized videos

## Execution & review notes

Feature 1 implemented interactively; features 2–3 by headless GLM 5.2 dispatch agents, then reviewed. Review caught one real bug (fixed in `db0c351`): Go marshals `[]uint8` as base64, so `/analysis` served strings the client's validation rejected — the precomputed path would silently never activate. Now `[]int` + a wire-shape regression test, plus an ffmpeg `-t` cap so overlong tracks can't stall decodes.

## Verification

- `services/youtube-api`: `go vet` + full test suite (InnerTube parser fixtures, FFT sine-peak/DC, band dominance, range-parse tables, 206-from-cache httptest, JSON wire-shape)
- Live e2e: real playlists (200/200 complete import; 200-of-2120 truncated; 404/400 paths; cache hits), fabricated-cache `/analysis` 202→200 with sane band data, `/proxy` 206 byte-identical slices + 416 with zero upstream traffic
- `pnpm -r build` clean; server tests 38/38; types tests 22/22

## Deploy notes

- youtube-api needs a docker image **rebuild** (`build --no-cache` if yt-dlp should bump too)
- Nakama container restart required for the module changes
- New env knob: `MAX_CACHEABLE_VIDEO_MB` (optional, default 50)
- Known follow-up: FFT normalization is approximate vs WebAudio — worth an A/B look on real music (first play live vs second play precomputed) and a gain nudge if the wall reacts differently

🤖 Generated with [Claude Code](https://claude.com/claude-code)